### PR TITLE
fix: language switch dialog not showing on second click after clicking "Later"

### DIFF
--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -1128,14 +1128,6 @@ extension AppDelegate {
         guard let code = sender.representedObject as? String,
               code != Settings.appLanguage else { return }
 
-        Settings.appLanguage = code
-        if code.isEmpty {
-            UserDefaults.standard.removeObject(forKey: "AppleLanguages")
-        } else {
-            UserDefaults.standard.set([code], forKey: "AppleLanguages")
-        }
-        UserDefaults.standard.synchronize()
-
         let alert = NSAlert()
         alert.messageText = NSLocalizedString("Language", comment: "")
         alert.informativeText = NSLocalizedString("Language change requires restart", comment: "")
@@ -1143,6 +1135,13 @@ extension AppDelegate {
         alert.addButton(withTitle: NSLocalizedString("Later", comment: ""))
 
         if alert.runModal() == .alertFirstButtonReturn {
+            Settings.appLanguage = code
+            if code.isEmpty {
+                UserDefaults.standard.removeObject(forKey: "AppleLanguages")
+            } else {
+                UserDefaults.standard.set([code], forKey: "AppleLanguages")
+            }
+            UserDefaults.standard.synchronize()
             restartApp()
         }
     }


### PR DESCRIPTION
fixed #15, thank you for taking the time to review the code; it was modified by Copilot.

## Problem
When switching language (e.g. to English), a restart dialog appears. If the user clicks "Later" (稍后), clicking the same language again no longer shows the dialog.

## Root Cause
`Settings.appLanguage` and `AppleLanguages` were updated **before** the dialog was shown. After clicking "Later", the saved language already matched the selected one, so the guard `code != Settings.appLanguage` returned early on subsequent clicks.

## Fix
Moved `Settings.appLanguage` and `AppleLanguages` updates into the "Restart Now" branch only. Now settings are only persisted when the user confirms the restart, allowing the dialog to reappear on subsequent clicks.

## Reproduction Steps
1. Click to switch language to English
2. In the restart dialog, click "Later" (稍后)
3. Click to switch to English again → **Before**: dialog doesn't appear; **After**: dialog appears correctly