### PR TITLE
feat: add tray icon customization in preferences window

### DIFF
--- a/ClashFX.xcodeproj/project.pbxproj
+++ b/ClashFX.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		4989F98E20D0AE990001E564 /* sampleConfig.yaml in Resources */ = {isa = PBXBuildFile; fileRef = 4989F98D20D0AE990001E564 /* sampleConfig.yaml */; };
 		498BC2532929CC2A00CA8084 /* SettingTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498BC2522929CC2A00CA8084 /* SettingTabViewController.swift */; };
 		498BC2552929CCAE00CA8084 /* GeneralSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498BC2542929CCAE00CA8084 /* GeneralSettingViewController.swift */; };
+		F276EBE7CC200CD8AF0A5D22 /* AppearanceSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78B3264153DCEBB811868F5A /* AppearanceSettingViewController.swift */; };
 		498D87D82A617D2200CD456F /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498D87D72A617D2200CD456F /* DashboardViewController.swift */; };
 		498D87DA2A617E9900CD456F /* DashboardSubViewControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498D87D92A617E9900CD456F /* DashboardSubViewControllerProtocol.swift */; };
 		4991D2282A5646D200978143 /* ConnectionProxyClientCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4991D2272A5646D200978143 /* ConnectionProxyClientCellView.swift */; };
@@ -67,6 +68,7 @@
 		4991D2302A564DDC00978143 /* SpeedUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4991D22F2A564DDC00978143 /* SpeedUtils.swift */; };
 		4991D2322A565E6A00978143 /* Combine+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4991D2312A565E6A00978143 /* Combine+Ext.swift */; };
 		4994B5542A47C4FF00E595B9 /* NormalMenuItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4994B5532A47C4FF00E595B9 /* NormalMenuItemView.swift */; };
+		78E0F1560AFD95A584F979B9 /* TrayIconPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFBA643EF41EB65C39E5574 /* TrayIconPickerView.swift */; };
 		499976C821359F0400E7BF83 /* ClashWebViewContoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499976C721359F0400E7BF83 /* ClashWebViewContoller.swift */; };
 		499A485522ED707300F6C675 /* RemoteConfigViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499A485322ED707300F6C675 /* RemoteConfigViewController.swift */; };
 		499A485822ED715200F6C675 /* RemoteConfigModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499A485722ED715200F6C675 /* RemoteConfigModel.swift */; };
@@ -234,6 +236,7 @@
 		4989F98D20D0AE990001E564 /* sampleConfig.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = sampleConfig.yaml; sourceTree = "<group>"; };
 		498BC2522929CC2A00CA8084 /* SettingTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTabViewController.swift; sourceTree = "<group>"; };
 		498BC2542929CCAE00CA8084 /* GeneralSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingViewController.swift; sourceTree = "<group>"; };
+		78B3264153DCEBB811868F5A /* AppearanceSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingViewController.swift; sourceTree = "<group>"; };
 		498D87D72A617D2200CD456F /* DashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewController.swift; sourceTree = "<group>"; };
 		498D87D92A617E9900CD456F /* DashboardSubViewControllerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardSubViewControllerProtocol.swift; sourceTree = "<group>"; };
 		4991D2272A5646D200978143 /* ConnectionProxyClientCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionProxyClientCellView.swift; sourceTree = "<group>"; };
@@ -243,6 +246,7 @@
 		4991D22F2A564DDC00978143 /* SpeedUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedUtils.swift; sourceTree = "<group>"; };
 		4991D2312A565E6A00978143 /* Combine+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Combine+Ext.swift"; sourceTree = "<group>"; };
 		4994B5532A47C4FF00E595B9 /* NormalMenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalMenuItemView.swift; sourceTree = "<group>"; };
+		6DFBA643EF41EB65C39E5574 /* TrayIconPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayIconPickerView.swift; sourceTree = "<group>"; };
 		499976C721359F0400E7BF83 /* ClashWebViewContoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClashWebViewContoller.swift; sourceTree = "<group>"; };
 		499A485322ED707300F6C675 /* RemoteConfigViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigViewController.swift; sourceTree = "<group>"; };
 		499A485722ED715200F6C675 /* RemoteConfigModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigModel.swift; sourceTree = "<group>"; };
@@ -478,6 +482,7 @@
 				493A9F272453E60400D35296 /* ProxyDelayHistoryMenu.swift */,
 				49228456270AADE20027A4B6 /* RemoteConfigUpdateIntervalSettingView.swift */,
 				4994B5532A47C4FF00E595B9 /* NormalMenuItemView.swift */,
+				6DFBA643EF41EB65C39E5574 /* TrayIconPickerView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -547,6 +552,7 @@
 			children = (
 				498BC2522929CC2A00CA8084 /* SettingTabViewController.swift */,
 				498BC2542929CCAE00CA8084 /* GeneralSettingViewController.swift */,
+				78B3264153DCEBB811868F5A /* AppearanceSettingViewController.swift */,
 				49281C7F2A1F01FA00F60935 /* DebugSettingViewController.swift */,
 				4905A2C42A2058B000AEDA2E /* GlobalShortCutViewController.swift */,
 			);
@@ -1017,6 +1023,7 @@
 				4913C82321157D0200F6B87C /* Notification.swift in Sources */,
 				8ACD21BD27A04ED500BC4632 /* ProxyModeChangeCommand.swift in Sources */,
 				498BC2552929CCAE00CA8084 /* GeneralSettingViewController.swift in Sources */,
+				F276EBE7CC200CD8AF0A5D22 /* AppearanceSettingViewController.swift in Sources */,
 				498D87D82A617D2200CD456F /* DashboardViewController.swift in Sources */,
 				4991D22E2A564A4200978143 /* ConnectionTextCellView.swift in Sources */,
 				49228457270AADE20027A4B6 /* RemoteConfigUpdateIntervalSettingView.swift in Sources */,
@@ -1062,6 +1069,7 @@
 				49D176A9235614340093DD7B /* ProxyGroupSpeedTestMenuItem.swift in Sources */,
 				F976275C23634DF8000EDEFE /* LoginServiceKit.swift in Sources */,
 				4994B5542A47C4FF00E595B9 /* NormalMenuItemView.swift in Sources */,
+				78E0F1560AFD95A584F979B9 /* TrayIconPickerView.swift in Sources */,
 				0AD7506B2A5B9A04001FFBBD /* ConnectionLeftPannelViewModel.swift in Sources */,
 				F92D0B2E236D35C000575E15 /* ProxyItemView.swift in Sources */,
 				49BB31E7246853EA008A4CB0 /* ICloudManager.swift in Sources */,

--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -1163,6 +1163,7 @@ extension AppDelegate {
             NSApp.terminate(nil)
         }
     }
+
 }
 
 // MARK: Streaming Info

--- a/ClashFX/Support Files/en.lproj/Localizable.strings
+++ b/ClashFX/Support Files/en.lproj/Localizable.strings
@@ -360,3 +360,23 @@
 
 /* No comment provided by engineer. */
 "Later" = "Later";
+/* No comment provided by engineer. */
+"Select Tray Icon Image" = "Select Tray Icon Image";
+
+/* No comment provided by engineer. */
+"Failed to change tray icon" = "Failed to change tray icon";
+
+/* No comment provided by engineer. */
+"Drop PNG here" = "Drop PNG here";
+
+/* No comment provided by engineer. */
+"Select Image" = "Select Image";
+
+/* No comment provided by engineer. */
+"Reset" = "Reset";
+
+/* No comment provided by engineer. */
+"Appearance" = "Appearance";
+
+/* No comment provided by engineer. */
+"Tray Icon" = "Tray Icon";

--- a/ClashFX/Support Files/en.lproj/Localizable.strings
+++ b/ClashFX/Support Files/en.lproj/Localizable.strings
@@ -380,3 +380,9 @@
 
 /* No comment provided by engineer. */
 "Tray Icon" = "Tray Icon";
+
+/* No comment provided by engineer. */
+"The file could not be loaded as an image." = "The file could not be loaded as an image.";
+
+/* No comment provided by engineer. */
+"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels." = "Image is too large (%d×%d). Maximum allowed size is %d×%d pixels.";

--- a/ClashFX/Support Files/en.lproj/Localizable.strings
+++ b/ClashFX/Support Files/en.lproj/Localizable.strings
@@ -365,6 +365,7 @@
 
 /* No comment provided by engineer. */
 "Failed to change tray icon" = "Failed to change tray icon";
+"Failed to reset tray icon" = "Failed to reset tray icon";
 
 /* No comment provided by engineer. */
 "Drop PNG here" = "Drop PNG here";
@@ -385,4 +386,4 @@
 "The file could not be loaded as an image." = "The file could not be loaded as an image.";
 
 /* No comment provided by engineer. */
-"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels." = "Image is too large (%d×%d). Maximum allowed size is %d×%d pixels.";
+"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels. Recommended size is 36×36 pixels (72×72 for Retina @2x)." = "Image is too large (%d×%d). Maximum allowed size is %d×%d pixels. Recommended size is 36×36 pixels (72×72 for Retina @2x).";

--- a/ClashFX/Support Files/ja.lproj/Localizable.strings
+++ b/ClashFX/Support Files/ja.lproj/Localizable.strings
@@ -360,3 +360,23 @@
 
 /* No comment provided by engineer. */
 "Later" = "後で";
+/* No comment provided by engineer. */
+"Select Tray Icon Image" = "トレイアイコン画像を選択";
+
+/* No comment provided by engineer. */
+"Failed to change tray icon" = "トレイアイコンの変更に失敗しました";
+
+/* No comment provided by engineer. */
+"Drop PNG here" = "PNGをドロップ";
+
+/* No comment provided by engineer. */
+"Select Image" = "画像を選択";
+
+/* No comment provided by engineer. */
+"Reset" = "リセット";
+
+/* No comment provided by engineer. */
+"Appearance" = "外観";
+
+/* No comment provided by engineer. */
+"Tray Icon" = "トレイアイコン";

--- a/ClashFX/Support Files/ja.lproj/Localizable.strings
+++ b/ClashFX/Support Files/ja.lproj/Localizable.strings
@@ -365,6 +365,7 @@
 
 /* No comment provided by engineer. */
 "Failed to change tray icon" = "トレイアイコンの変更に失敗しました";
+"Failed to reset tray icon" = "トレイアイコンのリセットに失敗しました";
 
 /* No comment provided by engineer. */
 "Drop PNG here" = "PNGをドロップ";
@@ -385,4 +386,4 @@
 "The file could not be loaded as an image." = "ファイルを画像として読み込めませんでした。";
 
 /* No comment provided by engineer. */
-"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels." = "画像が大きすぎます（%d×%d）。最大許容サイズは %d×%d ピクセルです。";
+"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels. Recommended size is 36×36 pixels (72×72 for Retina @2x)." = "画像が大きすぎます（%d×%d）。最大許容サイズは %d×%d ピクセルです。推奨サイズは 36×36 ピクセル（Retina @2x の場合は 72×72）です。";

--- a/ClashFX/Support Files/ja.lproj/Localizable.strings
+++ b/ClashFX/Support Files/ja.lproj/Localizable.strings
@@ -380,3 +380,9 @@
 
 /* No comment provided by engineer. */
 "Tray Icon" = "トレイアイコン";
+
+/* No comment provided by engineer. */
+"The file could not be loaded as an image." = "ファイルを画像として読み込めませんでした。";
+
+/* No comment provided by engineer. */
+"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels." = "画像が大きすぎます（%d×%d）。最大許容サイズは %d×%d ピクセルです。";

--- a/ClashFX/Support Files/ru.lproj/Localizable.strings
+++ b/ClashFX/Support Files/ru.lproj/Localizable.strings
@@ -360,3 +360,23 @@
 
 /* No comment provided by engineer. */
 "Later" = "Позже";
+/* No comment provided by engineer. */
+"Select Tray Icon Image" = "Выбрать изображение иконки трея";
+
+/* No comment provided by engineer. */
+"Failed to change tray icon" = "Не удалось изменить иконку трея";
+
+/* No comment provided by engineer. */
+"Drop PNG here" = "Перетащите PNG сюда";
+
+/* No comment provided by engineer. */
+"Select Image" = "Выбрать изображение";
+
+/* No comment provided by engineer. */
+"Reset" = "Сбросить";
+
+/* No comment provided by engineer. */
+"Appearance" = "Внешний вид";
+
+/* No comment provided by engineer. */
+"Tray Icon" = "Иконка трея";

--- a/ClashFX/Support Files/ru.lproj/Localizable.strings
+++ b/ClashFX/Support Files/ru.lproj/Localizable.strings
@@ -365,6 +365,7 @@
 
 /* No comment provided by engineer. */
 "Failed to change tray icon" = "Не удалось изменить иконку трея";
+"Failed to reset tray icon" = "Не удалось сбросить иконку трея";
 
 /* No comment provided by engineer. */
 "Drop PNG here" = "Перетащите PNG сюда";
@@ -385,4 +386,4 @@
 "The file could not be loaded as an image." = "Не удалось загрузить файл как изображение.";
 
 /* No comment provided by engineer. */
-"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels." = "Изображение слишком большое (%d×%d). Максимально допустимый размер — %d×%d пикселей.";
+"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels. Recommended size is 36×36 pixels (72×72 for Retina @2x)." = "Изображение слишком большое (%d×%d). Максимально допустимый размер — %d×%d пикселей. Рекомендуемый размер — 36×36 пикселей (72×72 для Retina @2x).";

--- a/ClashFX/Support Files/ru.lproj/Localizable.strings
+++ b/ClashFX/Support Files/ru.lproj/Localizable.strings
@@ -380,3 +380,9 @@
 
 /* No comment provided by engineer. */
 "Tray Icon" = "Иконка трея";
+
+/* No comment provided by engineer. */
+"The file could not be loaded as an image." = "Не удалось загрузить файл как изображение.";
+
+/* No comment provided by engineer. */
+"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels." = "Изображение слишком большое (%d×%d). Максимально допустимый размер — %d×%d пикселей.";

--- a/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
@@ -397,3 +397,23 @@
 
 /* No comment provided by engineer. */
 "Later" = "稍后";
+/* No comment provided by engineer. */
+"Select Tray Icon Image" = "选择托盘图标图片";
+
+/* No comment provided by engineer. */
+"Failed to change tray icon" = "更换托盘图标失败";
+
+/* No comment provided by engineer. */
+"Drop PNG here" = "拖入 PNG 图片";
+
+/* No comment provided by engineer. */
+"Select Image" = "选择图片";
+
+/* No comment provided by engineer. */
+"Reset" = "重置";
+
+/* No comment provided by engineer. */
+"Appearance" = "外观";
+
+/* No comment provided by engineer. */
+"Tray Icon" = "托盘图标";

--- a/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
@@ -417,3 +417,9 @@
 
 /* No comment provided by engineer. */
 "Tray Icon" = "托盘图标";
+
+/* No comment provided by engineer. */
+"The file could not be loaded as an image." = "无法将该文件加载为图片。";
+
+/* No comment provided by engineer. */
+"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels." = "图片尺寸过大（%d×%d）。最大允许尺寸为 %d×%d 像素。";

--- a/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
@@ -402,6 +402,7 @@
 
 /* No comment provided by engineer. */
 "Failed to change tray icon" = "更换托盘图标失败";
+"Failed to reset tray icon" = "重置托盘图标失败";
 
 /* No comment provided by engineer. */
 "Drop PNG here" = "拖入 PNG 图片";
@@ -422,4 +423,4 @@
 "The file could not be loaded as an image." = "无法将该文件加载为图片。";
 
 /* No comment provided by engineer. */
-"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels." = "图片尺寸过大（%d×%d）。最大允许尺寸为 %d×%d 像素。";
+"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels. Recommended size is 36×36 pixels (72×72 for Retina @2x)." = "图片尺寸过大（%d×%d）。最大允许尺寸为 %d×%d 像素。推荐尺寸为 36×36 像素（Retina @2x 为 72×72）。";

--- a/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
@@ -360,3 +360,23 @@
 
 /* No comment provided by engineer. */
 "Later" = "稍後";
+/* No comment provided by engineer. */
+"Select Tray Icon Image" = "選擇托盤圖標圖片";
+
+/* No comment provided by engineer. */
+"Failed to change tray icon" = "更換托盤圖標失敗";
+
+/* No comment provided by engineer. */
+"Drop PNG here" = "拖入 PNG 圖片";
+
+/* No comment provided by engineer. */
+"Select Image" = "選擇圖片";
+
+/* No comment provided by engineer. */
+"Reset" = "重置";
+
+/* No comment provided by engineer. */
+"Appearance" = "外觀";
+
+/* No comment provided by engineer. */
+"Tray Icon" = "托盤圖標";

--- a/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
@@ -361,10 +361,10 @@
 /* No comment provided by engineer. */
 "Later" = "稍後";
 /* No comment provided by engineer. */
-"Select Tray Icon Image" = "選擇托盤圖標圖片";
+"Select Tray Icon Image" = "選擇選單列圖像";
 
 /* No comment provided by engineer. */
-"Failed to change tray icon" = "更換托盤圖標失敗";
+"Failed to change tray icon" = "更換選單列圖像失敗";
 
 /* No comment provided by engineer. */
 "Drop PNG here" = "拖入 PNG 圖片";
@@ -379,4 +379,10 @@
 "Appearance" = "外觀";
 
 /* No comment provided by engineer. */
-"Tray Icon" = "托盤圖標";
+"Tray Icon" = "選單列圖像";
+
+/* No comment provided by engineer. */
+"The file could not be loaded as an image." = "無法將該檔案載入為圖片。";
+
+/* No comment provided by engineer. */
+"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels." = "圖片尺寸過大（%d×%d）。最大允許尺寸為 %d×%d 像素。";

--- a/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
@@ -365,6 +365,7 @@
 
 /* No comment provided by engineer. */
 "Failed to change tray icon" = "更換選單列圖像失敗";
+"Failed to reset tray icon" = "重置選單列圖像失敗";
 
 /* No comment provided by engineer. */
 "Drop PNG here" = "拖入 PNG 圖片";
@@ -385,4 +386,4 @@
 "The file could not be loaded as an image." = "無法將該檔案載入為圖片。";
 
 /* No comment provided by engineer. */
-"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels." = "圖片尺寸過大（%d×%d）。最大允許尺寸為 %d×%d 像素。";
+"Image is too large (%d×%d). Maximum allowed size is %d×%d pixels. Recommended size is 36×36 pixels (72×72 for Retina @2x)." = "圖片尺寸過大（%d×%d）。最大允許尺寸為 %d×%d 像素。推薦尺寸為 36×36 像素（Retina @2x 為 72×72）。";

--- a/ClashFX/ViewControllers/Settings/AppearanceSettingViewController.swift
+++ b/ClashFX/ViewControllers/Settings/AppearanceSettingViewController.swift
@@ -1,0 +1,48 @@
+//
+//  AppearanceSettingViewController.swift
+//  ClashFX
+//
+//  Created by copilot on 2026/4/15.
+//
+
+import Cocoa
+
+class AppearanceSettingViewController: NSViewController {
+    override func loadView() {
+        let width: CGFloat = 400
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: width, height: 120))
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+
+        let box = NSBox()
+        box.translatesAutoresizingMaskIntoConstraints = false
+        box.title = NSLocalizedString("Tray Icon", comment: "")
+
+        let picker = TrayIconPickerView()
+        box.contentView?.addSubview(picker)
+
+        if let cv = box.contentView {
+            NSLayoutConstraint.activate([
+                picker.topAnchor.constraint(equalTo: cv.topAnchor, constant: 10),
+                picker.leadingAnchor.constraint(equalTo: cv.leadingAnchor, constant: 20),
+                picker.trailingAnchor.constraint(lessThanOrEqualTo: cv.trailingAnchor, constant: -20),
+                cv.bottomAnchor.constraint(equalTo: picker.bottomAnchor, constant: 10),
+            ])
+        }
+
+        contentView.addSubview(box)
+        NSLayoutConstraint.activate([
+            box.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 20),
+            box.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            box.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            contentView.bottomAnchor.constraint(greaterThanOrEqualTo: box.bottomAnchor, constant: 20),
+        ])
+
+        view = contentView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = NSLocalizedString("Appearance", comment: "")
+        preferredContentSize = NSSize(width: 400, height: 120)
+    }
+}

--- a/ClashFX/ViewControllers/Settings/AppearanceSettingViewController.swift
+++ b/ClashFX/ViewControllers/Settings/AppearanceSettingViewController.swift
@@ -43,6 +43,6 @@ class AppearanceSettingViewController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = NSLocalizedString("Appearance", comment: "")
-        preferredContentSize = NSSize(width: 400, height: 120)
+        preferredContentSize = NSSize(width: 400, height: 160)
     }
 }

--- a/ClashFX/ViewControllers/Settings/SettingTabViewController.swift
+++ b/ClashFX/ViewControllers/Settings/SettingTabViewController.swift
@@ -18,6 +18,16 @@ class SettingTabViewController: NSTabViewController, NibLoadable {
                 item.image = nil
             }
         }
+        insertAppearanceTab()
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func insertAppearanceTab() {
+        let vc = AppearanceSettingViewController()
+        let item = NSTabViewItem(viewController: vc)
+        item.label = NSLocalizedString("Appearance", comment: "")
+        item.image = NSImage(systemSymbolName: "paintbrush", accessibilityDescription: nil)
+            ?? NSImage(named: NSImage.colorPanelName)
+        insertTabViewItem(item, at: 1)
     }
 }

--- a/ClashFX/ViewControllers/Settings/SettingTabViewController.swift
+++ b/ClashFX/ViewControllers/Settings/SettingTabViewController.swift
@@ -26,8 +26,11 @@ class SettingTabViewController: NSTabViewController, NibLoadable {
         let vc = AppearanceSettingViewController()
         let item = NSTabViewItem(viewController: vc)
         item.label = NSLocalizedString("Appearance", comment: "")
-        item.image = NSImage(systemSymbolName: "paintbrush", accessibilityDescription: nil)
-            ?? NSImage(named: NSImage.colorPanelName)
+        if #available(macOS 11.0, *) {
+            item.image = NSImage(systemSymbolName: "paintbrush", accessibilityDescription: nil)
+        } else {
+            item.image = NSImage(named: NSImage.colorPanelName)
+        }
         insertTabViewItem(item, at: 1)
     }
 }

--- a/ClashFX/Views/StatusItem/StatusItemTool.swift
+++ b/ClashFX/Views/StatusItem/StatusItemTool.swift
@@ -9,8 +9,11 @@
 import AppKit
 
 enum StatusItemTool {
-    static let menuImage: NSImage = {
-        let customImagePath = (NSHomeDirectory() as NSString).appendingPathComponent("/.config/clashfx/menuImage.png")
+    static let customImagePath = (NSHomeDirectory() as NSString).appendingPathComponent("/.config/clashfx/menuImage.png")
+
+    static var menuImage: NSImage = loadMenuImage()
+
+    static func loadMenuImage() -> NSImage {
         if let image = NSImage(contentsOfFile: customImagePath) {
             image.isTemplate = true
             return image
@@ -21,7 +24,11 @@ enum StatusItemTool {
             return image
         }
         return NSImage()
-    }()
+    }
+
+    static func reloadMenuImage() {
+        menuImage = loadMenuImage()
+    }
 
     static let font: NSFont = {
         let fontSize: CGFloat = 9

--- a/ClashFX/Views/StatusItem/StatusItemTool.swift
+++ b/ClashFX/Views/StatusItem/StatusItemTool.swift
@@ -11,6 +11,7 @@ import AppKit
 enum StatusItemTool {
     static let customImagePath = (NSHomeDirectory() as NSString).appendingPathComponent("/.config/clashfx/menuImage.png")
 
+    /// Must be accessed on main thread only.
     static var menuImage: NSImage = loadMenuImage()
 
     static func loadMenuImage() -> NSImage {

--- a/ClashFX/Views/TrayIconPickerView.swift
+++ b/ClashFX/Views/TrayIconPickerView.swift
@@ -1,0 +1,184 @@
+//
+//  TrayIconPickerView.swift
+//  ClashFX
+//
+//  Created by copilot on 2026/4/15.
+//
+
+import Cocoa
+
+class TrayIconPickerView: NSView {
+    private let imageView = NSImageView()
+    private let placeholderLabel = NSTextField(labelWithString: "")
+    private let selectButton = NSButton()
+    private let resetButton = NSButton()
+
+    var onImageChanged: (() -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupViews()
+        registerForDraggedTypes([.fileURL])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupViews() {
+        translatesAutoresizingMaskIntoConstraints = false
+
+        // Image preview area (acts as drop zone)
+        let dropZone = NSView()
+        dropZone.translatesAutoresizingMaskIntoConstraints = false
+        dropZone.wantsLayer = true
+        dropZone.layer?.borderWidth = 1.5
+        dropZone.layer?.borderColor = NSColor.separatorColor.cgColor
+        dropZone.layer?.cornerRadius = 8
+
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.image = StatusItemTool.menuImage
+        dropZone.addSubview(imageView)
+
+        placeholderLabel.translatesAutoresizingMaskIntoConstraints = false
+        placeholderLabel.stringValue = NSLocalizedString("Drop PNG here", comment: "")
+        placeholderLabel.textColor = .secondaryLabelColor
+        placeholderLabel.font = NSFont.systemFont(ofSize: 11)
+        placeholderLabel.alignment = .center
+        dropZone.addSubview(placeholderLabel)
+
+        addSubview(dropZone)
+
+        // Buttons stack
+        selectButton.translatesAutoresizingMaskIntoConstraints = false
+        selectButton.title = NSLocalizedString("Select Image", comment: "")
+        selectButton.bezelStyle = .rounded
+        selectButton.target = self
+        selectButton.action = #selector(selectImage)
+
+        resetButton.translatesAutoresizingMaskIntoConstraints = false
+        resetButton.title = NSLocalizedString("Reset", comment: "")
+        resetButton.bezelStyle = .rounded
+        resetButton.target = self
+        resetButton.action = #selector(resetImage)
+
+        let buttonStack = NSStackView(views: [selectButton, resetButton])
+        buttonStack.translatesAutoresizingMaskIntoConstraints = false
+        buttonStack.orientation = .horizontal
+        buttonStack.spacing = 8
+        addSubview(buttonStack)
+
+        NSLayoutConstraint.activate([
+            dropZone.topAnchor.constraint(equalTo: topAnchor),
+            dropZone.leadingAnchor.constraint(equalTo: leadingAnchor),
+            dropZone.widthAnchor.constraint(equalToConstant: 64),
+            dropZone.heightAnchor.constraint(equalToConstant: 64),
+
+            imageView.centerXAnchor.constraint(equalTo: dropZone.centerXAnchor),
+            imageView.centerYAnchor.constraint(equalTo: dropZone.centerYAnchor, constant: -8),
+            imageView.widthAnchor.constraint(equalToConstant: 32),
+            imageView.heightAnchor.constraint(equalToConstant: 32),
+
+            placeholderLabel.centerXAnchor.constraint(equalTo: dropZone.centerXAnchor),
+            placeholderLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 2),
+            placeholderLabel.widthAnchor.constraint(equalTo: dropZone.widthAnchor, constant: -4),
+
+            buttonStack.leadingAnchor.constraint(equalTo: dropZone.trailingAnchor, constant: 12),
+            buttonStack.centerYAnchor.constraint(equalTo: dropZone.centerYAnchor),
+
+            bottomAnchor.constraint(equalTo: dropZone.bottomAnchor),
+        ])
+
+        updateResetButtonVisibility()
+    }
+
+    private func updateResetButtonVisibility() {
+        resetButton.isHidden = !FileManager.default.fileExists(atPath: StatusItemTool.customImagePath)
+    }
+
+    // MARK: - Drag and Drop
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard let urls = sender.draggingPasteboard.readObjects(forClasses: [NSURL.self], options: [
+            .urlReadingFileURLsOnly: true,
+            .urlReadingContentsConformToTypes: ["public.png"],
+        ]) as? [URL], !urls.isEmpty else {
+            return []
+        }
+        subviews.first?.layer?.borderColor = NSColor.controlAccentColor.cgColor
+        return .copy
+    }
+
+    override func draggingExited(_ sender: NSDraggingInfo?) {
+        subviews.first?.layer?.borderColor = NSColor.separatorColor.cgColor
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        subviews.first?.layer?.borderColor = NSColor.separatorColor.cgColor
+        guard let urls = sender.draggingPasteboard.readObjects(forClasses: [NSURL.self], options: [
+            .urlReadingFileURLsOnly: true,
+            .urlReadingContentsConformToTypes: ["public.png"],
+        ]) as? [URL], let srcURL = urls.first else {
+            return false
+        }
+        return applyImage(from: srcURL)
+    }
+
+    // MARK: - Actions
+
+    @objc private func selectImage() {
+        let panel = NSOpenPanel()
+        panel.title = NSLocalizedString("Select Tray Icon Image", comment: "")
+        panel.allowedFileTypes = ["png"]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+
+        guard panel.runModal() == .OK, let srcURL = panel.url else { return }
+        _ = applyImage(from: srcURL)
+    }
+
+    @objc private func resetImage() {
+        let destPath = StatusItemTool.customImagePath
+        if FileManager.default.fileExists(atPath: destPath) {
+            try? FileManager.default.removeItem(atPath: destPath)
+        }
+        reloadIcon()
+    }
+
+    private func applyImage(from srcURL: URL) -> Bool {
+        let destPath = StatusItemTool.customImagePath
+        let destURL = URL(fileURLWithPath: destPath)
+        let destDir = destURL.deletingLastPathComponent()
+
+        do {
+            try FileManager.default.createDirectory(at: destDir, withIntermediateDirectories: true)
+            if FileManager.default.fileExists(atPath: destPath) {
+                try FileManager.default.removeItem(at: destURL)
+            }
+            try FileManager.default.copyItem(at: srcURL, to: destURL)
+        } catch {
+            let alert = NSAlert()
+            alert.messageText = NSLocalizedString("Failed to change tray icon", comment: "")
+            alert.informativeText = error.localizedDescription
+            alert.runModal()
+            return false
+        }
+        reloadIcon()
+        return true
+    }
+
+    private func reloadIcon() {
+        StatusItemTool.reloadMenuImage()
+        imageView.image = StatusItemTool.menuImage
+
+        if let view = AppDelegate.shared.statusItemView as? StatusItemView {
+            view.imageView.image = StatusItemTool.menuImage
+        }
+
+        updateResetButtonVisibility()
+        onImageChanged?()
+    }
+}

--- a/ClashFX/Views/TrayIconPickerView.swift
+++ b/ClashFX/Views/TrayIconPickerView.swift
@@ -6,6 +6,7 @@
 //
 
 import Cocoa
+import UniformTypeIdentifiers
 
 class TrayIconPickerView: NSView {
     private let dropZone = NSView()
@@ -131,7 +132,11 @@ class TrayIconPickerView: NSView {
     @objc private func selectImage() {
         let panel = NSOpenPanel()
         panel.title = NSLocalizedString("Select Tray Icon Image", comment: "")
-        panel.allowedFileTypes = ["png"]
+        if #available(macOS 11.0, *) {
+            panel.allowedContentTypes = [.png]
+        } else {
+            panel.allowedFileTypes = ["png"]
+        }
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
@@ -143,12 +148,21 @@ class TrayIconPickerView: NSView {
     @objc private func resetImage() {
         let destPath = StatusItemTool.customImagePath
         if FileManager.default.fileExists(atPath: destPath) {
-            try? FileManager.default.removeItem(atPath: destPath)
+            do {
+                try FileManager.default.removeItem(atPath: destPath)
+            } catch {
+                let alert = NSAlert()
+                alert.alertStyle = .warning
+                alert.messageText = NSLocalizedString("Failed to reset tray icon", comment: "")
+                alert.informativeText = error.localizedDescription
+                alert.runModal()
+                return
+            }
         }
         reloadIcon()
     }
 
-    private static let maxIconDimension: CGFloat = 128
+    private static let maxIconDimension: CGFloat = 256
 
     private func applyImage(from srcURL: URL) -> Bool {
         guard let image = NSImage(contentsOf: srcURL) else {
@@ -166,7 +180,7 @@ class TrayIconPickerView: NSView {
                 alert.alertStyle = .warning
                 alert.messageText = NSLocalizedString("Failed to change tray icon", comment: "")
                 alert.informativeText = String(
-                    format: NSLocalizedString("Image is too large (%d×%d). Maximum allowed size is %d×%d pixels.", comment: ""),
+                    format: NSLocalizedString("Image is too large (%d×%d). Maximum allowed size is %d×%d pixels. Recommended size is 36×36 pixels (72×72 for Retina @2x).", comment: ""),
                     Int(pixelSize.width), Int(pixelSize.height),
                     Int(TrayIconPickerView.maxIconDimension), Int(TrayIconPickerView.maxIconDimension)
                 )

--- a/ClashFX/Views/TrayIconPickerView.swift
+++ b/ClashFX/Views/TrayIconPickerView.swift
@@ -8,12 +8,11 @@
 import Cocoa
 
 class TrayIconPickerView: NSView {
+    private let dropZone = NSView()
     private let imageView = NSImageView()
     private let placeholderLabel = NSTextField(labelWithString: "")
     private let selectButton = NSButton()
     private let resetButton = NSButton()
-
-    var onImageChanged: (() -> Void)?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -30,7 +29,6 @@ class TrayIconPickerView: NSView {
         translatesAutoresizingMaskIntoConstraints = false
 
         // Image preview area (acts as drop zone)
-        let dropZone = NSView()
         dropZone.translatesAutoresizingMaskIntoConstraints = false
         dropZone.wantsLayer = true
         dropZone.layer?.borderWidth = 1.5
@@ -107,16 +105,16 @@ class TrayIconPickerView: NSView {
         ]) as? [URL], !urls.isEmpty else {
             return []
         }
-        subviews.first?.layer?.borderColor = NSColor.controlAccentColor.cgColor
+        dropZone.layer?.borderColor = NSColor.controlAccentColor.cgColor
         return .copy
     }
 
     override func draggingExited(_ sender: NSDraggingInfo?) {
-        subviews.first?.layer?.borderColor = NSColor.separatorColor.cgColor
+        dropZone.layer?.borderColor = NSColor.separatorColor.cgColor
     }
 
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
-        subviews.first?.layer?.borderColor = NSColor.separatorColor.cgColor
+        dropZone.layer?.borderColor = NSColor.separatorColor.cgColor
         guard let urls = sender.draggingPasteboard.readObjects(forClasses: [NSURL.self], options: [
             .urlReadingFileURLsOnly: true,
             .urlReadingContentsConformToTypes: ["public.png"],
@@ -148,7 +146,34 @@ class TrayIconPickerView: NSView {
         reloadIcon()
     }
 
+    private static let maxIconDimension: CGFloat = 128
+
     private func applyImage(from srcURL: URL) -> Bool {
+        guard let image = NSImage(contentsOf: srcURL) else {
+            let alert = NSAlert()
+            alert.messageText = NSLocalizedString("Failed to change tray icon", comment: "")
+            alert.informativeText = NSLocalizedString("The file could not be loaded as an image.", comment: "")
+            alert.runModal()
+            return false
+        }
+
+        let pixelSize = image.representations.first.map {
+            NSSize(width: $0.pixelsWide, height: $0.pixelsHigh)
+        } ?? image.size
+
+        if pixelSize.width > TrayIconPickerView.maxIconDimension || pixelSize.height > TrayIconPickerView.maxIconDimension {
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = NSLocalizedString("Failed to change tray icon", comment: "")
+            alert.informativeText = String(
+                format: NSLocalizedString("Image is too large (%d×%d). Maximum allowed size is %d×%d pixels.", comment: ""),
+                Int(pixelSize.width), Int(pixelSize.height),
+                Int(TrayIconPickerView.maxIconDimension), Int(TrayIconPickerView.maxIconDimension)
+            )
+            alert.runModal()
+            return false
+        }
+
         let destPath = StatusItemTool.customImagePath
         let destURL = URL(fileURLWithPath: destPath)
         let destDir = destURL.deletingLastPathComponent()
@@ -179,6 +204,5 @@ class TrayIconPickerView: NSView {
         }
 
         updateResetButtonVisibility()
-        onImageChanged?()
     }
 }

--- a/ClashFX/Views/TrayIconPickerView.swift
+++ b/ClashFX/Views/TrayIconPickerView.swift
@@ -89,11 +89,13 @@ class TrayIconPickerView: NSView {
             bottomAnchor.constraint(equalTo: dropZone.bottomAnchor),
         ])
 
-        updateResetButtonVisibility()
+        updateIconPreview()
     }
 
-    private func updateResetButtonVisibility() {
-        resetButton.isHidden = !FileManager.default.fileExists(atPath: StatusItemTool.customImagePath)
+    private func updateIconPreview() {
+        let hasCustom = FileManager.default.fileExists(atPath: StatusItemTool.customImagePath)
+        placeholderLabel.isHidden = hasCustom
+        resetButton.isHidden = !hasCustom
     }
 
     // MARK: - Drag and Drop
@@ -157,21 +159,20 @@ class TrayIconPickerView: NSView {
             return false
         }
 
-        let pixelSize = image.representations.first.map {
-            NSSize(width: $0.pixelsWide, height: $0.pixelsHigh)
-        } ?? image.size
-
-        if pixelSize.width > TrayIconPickerView.maxIconDimension || pixelSize.height > TrayIconPickerView.maxIconDimension {
-            let alert = NSAlert()
-            alert.alertStyle = .warning
-            alert.messageText = NSLocalizedString("Failed to change tray icon", comment: "")
-            alert.informativeText = String(
-                format: NSLocalizedString("Image is too large (%d×%d). Maximum allowed size is %d×%d pixels.", comment: ""),
-                Int(pixelSize.width), Int(pixelSize.height),
-                Int(TrayIconPickerView.maxIconDimension), Int(TrayIconPickerView.maxIconDimension)
-            )
-            alert.runModal()
-            return false
+        if let rep = image.representations.first {
+            let pixelSize = NSSize(width: rep.pixelsWide, height: rep.pixelsHigh)
+            if pixelSize.width > TrayIconPickerView.maxIconDimension || pixelSize.height > TrayIconPickerView.maxIconDimension {
+                let alert = NSAlert()
+                alert.alertStyle = .warning
+                alert.messageText = NSLocalizedString("Failed to change tray icon", comment: "")
+                alert.informativeText = String(
+                    format: NSLocalizedString("Image is too large (%d×%d). Maximum allowed size is %d×%d pixels.", comment: ""),
+                    Int(pixelSize.width), Int(pixelSize.height),
+                    Int(TrayIconPickerView.maxIconDimension), Int(TrayIconPickerView.maxIconDimension)
+                )
+                alert.runModal()
+                return false
+            }
         }
 
         let destPath = StatusItemTool.customImagePath
@@ -203,6 +204,6 @@ class TrayIconPickerView: NSView {
             view.imageView.image = StatusItemTool.menuImage
         }
 
-        updateResetButtonVisibility()
+        updateIconPreview()
     }
 }


### PR DESCRIPTION
resolved #5, thank you for taking the time to review the code; it was modified by Copilot.

Adds a new **Appearance** tab to the preferences window (after General), containing a tray icon picker that allows users to replace the status bar icon with a custom PNG image (saved to `~/.config/clashfx/menuImage.png`). Supports both drag-and-drop and click-to-select, with a reset button to restore the default icon.

### Changes

- **`StatusItemTool.swift`**: Refactored `menuImage` from `static let` (computed once) to `static var` backed by `loadMenuImage()`/`reloadMenuImage()` so the icon can be swapped at runtime. Extracted `customImagePath` as a shared constant.
- **`TrayIconPickerView.swift`** (new): Custom `NSView` with a drag-and-drop zone (PNG-only), image preview, "Select Image" button (opens `NSOpenPanel`), and "Reset" button to restore the default icon.
- **`AppearanceSettingViewController.swift`** (new): New view controller for the Appearance tab, hosting the tray icon picker inside a "Tray Icon" labeled box.
- **`SettingTabViewController.swift`**: Programmatically inserts the Appearance tab at index 1 (after General) with a `paintbrush` SF Symbol icon.
- **`AppDelegate.swift`**: Removed the previously added tray menu item in favor of the preferences UI.
- **Localizable.strings**: Added `"Appearance"`, `"Tray Icon"`, `"Drop PNG here"`, `"Select Image"`, `"Reset"`, `"Select Tray Icon Image"`, `"Failed to change tray icon"` across all 5 locales (en, zh-Hans, zh-Hant, ja, ru).