### PR TITLE
fix: fix appearance tab window height not adapting to content on tab switch (#9)

### DIFF
--- a/ClashFX/ViewControllers/Settings/AppearanceSettingViewController.swift
+++ b/ClashFX/ViewControllers/Settings/AppearanceSettingViewController.swift
@@ -8,6 +8,8 @@
 import Cocoa
 
 class AppearanceSettingViewController: NSViewController {
+    private var didComputePreferredSize = false
+
     override func loadView() {
         let width: CGFloat = 400
         let contentView = NSView(frame: NSRect(x: 0, y: 0, width: width, height: 240))
@@ -61,11 +63,17 @@ class AppearanceSettingViewController: NSViewController {
         ])
 
         view = contentView
+        title = NSLocalizedString("Appearance", comment: "")
+        preferredContentSize = NSSize(width: 420, height: 340)
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        title = NSLocalizedString("Appearance", comment: "")
-        preferredContentSize = NSSize(width: 420, height: 260)
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        guard !didComputePreferredSize else { return }
+        let fittingHeight = view.fittingSize.height
+        if fittingHeight > 0 {
+            didComputePreferredSize = true
+            preferredContentSize = NSSize(width: preferredContentSize.width, height: fittingHeight)
+        }
     }
 }

--- a/ClashFX/ViewControllers/Settings/AppearanceSettingViewController.swift
+++ b/ClashFX/ViewControllers/Settings/AppearanceSettingViewController.swift
@@ -64,7 +64,7 @@ class AppearanceSettingViewController: NSViewController {
 
         view = contentView
         title = NSLocalizedString("Appearance", comment: "")
-        preferredContentSize = NSSize(width: 420, height: 340)
+        preferredContentSize = NSSize(width: 420, height: 280)
     }
 
     override func viewDidLayout() {
@@ -74,6 +74,14 @@ class AppearanceSettingViewController: NSViewController {
         if fittingHeight > 0 {
             didComputePreferredSize = true
             preferredContentSize = NSSize(width: preferredContentSize.width, height: fittingHeight)
+            // If currently displayed, resize window immediately
+            if let window = view.window, view.superview != nil {
+                let newFrame = window.frameRect(forContentRect: NSRect(origin: .zero, size: preferredContentSize))
+                var frame = window.frame
+                frame.origin.y += frame.height - newFrame.height
+                frame.size.height = newFrame.height
+                window.setFrame(frame, display: true, animate: true)
+            }
         }
     }
 }

--- a/ClashFX/ViewControllers/Settings/SettingTabViewController.swift
+++ b/ClashFX/ViewControllers/Settings/SettingTabViewController.swift
@@ -22,6 +22,21 @@ class SettingTabViewController: NSTabViewController, NibLoadable {
         NSApp.activate(ignoringOtherApps: true)
     }
 
+    override func tabView(_ tabView: NSTabView, didSelect tabViewItem: NSTabViewItem?) {
+        super.tabView(tabView, didSelect: tabViewItem)
+        guard let window = view.window,
+              let vc = tabViewItem?.viewController else { return }
+        let contentSize = vc.preferredContentSize.height > 0
+            ? vc.preferredContentSize
+            : vc.view.frame.size
+        guard contentSize.height > 0 else { return }
+        let newFrame = window.frameRect(forContentRect: NSRect(origin: .zero, size: contentSize))
+        var frame = window.frame
+        frame.origin.y += frame.height - newFrame.height
+        frame.size.height = newFrame.height
+        window.setFrame(frame, display: true, animate: true)
+    }
+
     private func insertAppearanceTab() {
         let vc = AppearanceSettingViewController()
         let item = NSTabViewItem(viewController: vc)


### PR DESCRIPTION
resolved #24

The Appearance tab's window height was inherited from the previously selected tab, leaving large empty space below its content. `NSTabViewController` with `.toolbar` style does not automatically resize the window on tab switch.

### Changes

- **`SettingTabViewController`**: Override `tabView(_:didSelect:)` to animate the window to each tab's content size, using `preferredContentSize` (programmatic tabs) with `view.frame.size` fallback (storyboard tabs). Window anchors from the top edge during resize.
- **`AppearanceSettingViewController`**: Set `preferredContentSize` eagerly in `loadView()` with a static estimate, then refine once via `fittingSize` in `viewDidLayout()` (guarded by flag to avoid repeated updates).