### PR TITLE
ci(pr): converge with release workflow - direct xcodebuild + disk cleanup

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -30,6 +30,32 @@ jobs:
       run: |
         bash install_dependency.sh
 
-    - name: check
+    - name: free disk space before build
       run: |
-        bundle exec fastlane check
+        echo "Before cleanup: $(df -h / | tail -1 | awk '{print $4}') available"
+        sudo rm -rf /Users/runner/Library/Android 2>/dev/null || true
+        sudo rm -rf /Library/Frameworks/Mono.framework 2>/dev/null || true
+        sudo rm -rf /usr/local/share/dotnet 2>/dev/null || true
+        rm -rf ~/Library/Caches/CocoaPods 2>/dev/null || true
+        echo "After cleanup: $(df -h / | tail -1 | awk '{print $4}') available"
+
+    - name: build
+      run: |
+        echo "Building ClashFX (PR check, no signing)..."
+        xcodebuild clean build \
+          -workspace ClashFX.xcworkspace \
+          -scheme ClashFX \
+          -configuration Release \
+          -derivedDataPath ./build_derived_data \
+          CODE_SIGN_IDENTITY="-" \
+          ENABLE_HARDENED_RUNTIME=NO
+
+        APP_PATH=$(find ./build_derived_data/Build/Products/Release -name "ClashFX.app" -type d | head -n 1)
+
+        if [ -z "$APP_PATH" ]; then
+          echo "Error: ClashFX.app not found!"
+          find ./build_derived_data -name "ClashFX.app" -type d
+          exit 1
+        fi
+
+        echo "Build complete! App at: $APP_PATH"


### PR DESCRIPTION
## Why

After #26 (workflow alignment) and #27 (dependency lock + Ruby bump), the only remaining structural drift between \`pull_request.yaml\` and \`main.yml\` is:

| | main.yml (release) | pull_request.yaml (PR) |
|---|---|---|
| Build invocation | \`xcodebuild\` direct | \`bundle exec fastlane check\` |
| Disk cleanup | ✅ has it | ❌ missing |

The fastlane indirection was buying nothing — the \`check\` lane in Fastfile was just a thin \`build_app()\` wrapper with no signing, no pkg, no extra steps. Meanwhile the disk cleanup that release workflow added (commits 433f48d \"aggressively free disk space before build\" and dee4f3a \"create DMG in /tmp to avoid volume space issues\") is missing on PR builds, leaving them exposed to the same ENOSPC failures release workflow already hit.

## What

\`.github/workflows/pull_request.yaml\`:

- **Drop \`bundle exec fastlane check\`** → call \`xcodebuild\` directly with the same flags as \`main.yml\`'s \`build\` step
- **Add \`free disk space before build\` step** → mirrors release workflow's cleanup (removes Android SDK, Mono framework, .NET runtime, CocoaPods cache)
- **Add APP_PATH sanity check** → matches release workflow's pattern of failing fast if the build product is missing

## Result

PR and release workflows now share **identical setup** (checkout/Ruby/Go/Xcode/install_deps + disk cleanup + xcodebuild) and diverge only after build:
- Release continues into DMG creation → Sparkle signing → GitHub release upload → appcast update → website notification
- PR stops after the build sanity check

## Out of scope

- **Fastfile is left in place**. It's now unused by CI but still useful for local dev (\`bundle exec fastlane build\` for signed builds). Removing it is a separate decision.
- **Reusable workflow / composite action extraction** — possible future refactor if more drift creeps in, but with current near-identical setups, premature.

## Test plan

This PR self-validates: if the new \`pull_request.yaml\` runs cleanly on its own diff, the convergence is end-to-end verified.