### PR TITLE
release: update appcast.xml for v1.0.14

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -6,6 +6,24 @@
     <description>Most recent ClashFX updates</description>
     <language>en</language>
     <item>
+  <title>Version 1.0.14</title>
+  <description><![CDATA[
+    <h2>ClashFX v1.0.14</h2><ul><li><strong>Fixed menu bar icon shrinking when realtime speed is disabled</strong> — ClashFX had already fixed this once, but a later XIB layout change reintroduced a permanent leading constraint between the icon and hidden speed container. The status item now follows the original ClashFX fix again, so disabling realtime speed no longer compresses the tray icon.</li><li><strong>Fixed Config Editor appearance in dark and light mode</strong> — The raw editor, line number ruler, and visual editor sidebar previously used hard-coded dark colors. ClashFX now uses semantic system colors so the Config Editor follows the current macOS appearance correctly in both light and dark mode.</li><li><strong>Improved share-link generated configs for domestic sites</strong> — When ClashFX builds a minimal Clash config from `ss://` share-link subscriptions, it now enables `dns:` and adds direct rules for `baidu.com`, `bdimg.com`, and `bdstatic.com`, reducing cases where domestic domains fall through to `MATCH,Proxy`.</li><li><strong>Improved Settings tab icon compatibility on older macOS</strong> — The Settings window now falls back to generated icons on systems that do not support SF Symbols, instead of leaving missing tab icons.</li><li><strong>Improved menu bar speed text compatibility on older macOS</strong> — The status bar speed view now uses a legacy text-label fallback on older systems while keeping the custom draw path for newer macOS versions.</li></ul>
+  ]]></description>
+  <pubDate>Wed, 22 Apr 2026 06:36:44 +0000</pubDate>
+  <sparkle:version>1.0.14</sparkle:version>
+  <sparkle:shortVersionString>1.0.14</sparkle:shortVersionString>
+  <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
+  <enclosure
+    url="https://github.com/Clash-FX/ClashFX/releases/download/1.0.14/ClashFX.dmg"
+    sparkle:version="1.0.14"
+    sparkle:shortVersionString="1.0.14"
+    sparkle:edSignature="3wRaXw4mfwTErw11gIPbPWfcZsND/pxgAOFIZOmwIbLvLPEIydHjvDHQKfXxBxQ2rpwxP4NR4VSR8Du0Bk5RBA=="
+    length="87976193"
+    type="application/octet-stream"
+  />
+</item>
+    <item>
   <title>Version 1.0.13</title>
   <description><![CDATA[
     <h2>ClashFX v1.0.13</h2><ul><li><strong>Fixed double-encoded share-link subscriptions</strong> — Some providers (e.g. sub.cucloud.top) return a base64 payload where each individual proxy URI is itself base64-encoded a second time, so lines look like `c3M6Ly9...` instead of `ss://...`. ClashFX now detects and decodes these correctly, generates a valid Clash config with `Auto` (url-test) and `Proxy` (select) groups, and no longer shows "cannot unmarshal !!str" errors.</li><li><strong>Fixed domestic site access in Rules mode</strong> — When generating a config from share-link subscriptions, the rules section previously only contained `MATCH,Proxy`, routing all traffic through the proxy including Chinese domestic sites (Baidu, etc.). `GEOIP,private,DIRECT` and `GEOIP,CN,DIRECT` rules are now added before `MATCH,Proxy` so local and domestic traffic bypasses the proxy.</li><li><strong>Fixed blank speed display in menu bar</strong> — The upload/download speed text in the status bar was invisible on first launch. The initial draw call occurred before Auto Layout resolved the view bounds (height = 0), and subsequent updates were silently dropped if the speed values hadn't changed. Fixed by overriding `layout()` to re-trigger `needsDisplay` once bounds are non-zero.</li><li><strong>Fixed settings tab gray block on macOS 15 Sequoia</strong> — `NSTabViewController` with `.toolbar` style renders as a large gray block on macOS 15 due to toolbar layout changes. The settings window now uses `.segmentedControlOnTop` style on macOS 15+ for a clean appearance, while retaining `.toolbar` with proper SF Symbol icons on macOS 11–14.</li></ul>


### PR DESCRIPTION
Auto-generated by CI. Updates Sparkle appcast for v1.0.14.