### PR TITLE
feat: add a "Restart" menu item above "Quit" in the tray menu

### DIFF
--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -1084,6 +1084,10 @@ extension AppDelegate {
         NSApplication.shared.terminate(self)
     }
 
+    @IBAction func actionRestart(_ sender: Any) {
+        restartApp()
+    }
+
     @IBAction func actionMoreSetting(_ sender: Any) {
         ClashWindowController<SettingTabViewController>.create().showWindow(sender)
     }

--- a/ClashFX/Base.lproj/Main.storyboard
+++ b/ClashFX/Base.lproj/Main.storyboard
@@ -1040,6 +1040,12 @@
                                 </items>
                             </menu>
                         </menuItem>
+                        <menuItem title="Restart" id="rST-ap-p0x">
+                            <modifierMask key="keyEquivalentModifierMask"/>
+                            <connections>
+                                <action selector="actionRestart:" target="Voe-Tx-rLC" id="rST-ap-aCt"/>
+                            </connections>
+                        </menuItem>
                         <menuItem title="Quit" keyEquivalent="q" id="NXU-86-Eem">
                             <connections>
                                 <action selector="actionQuit:" target="Voe-Tx-rLC" id="ZtA-Bb-6xk"/>

--- a/ClashFX/ja.lproj/Main.strings
+++ b/ClashFX/ja.lproj/Main.strings
@@ -88,6 +88,9 @@
 /* Class = "NSMenuItem"; title = "Quit"; ObjectID = "NXU-86-Eem"; */
 "NXU-86-Eem.title" = "終了";
 
+/* Class = "NSMenuItem"; title = "Restart"; ObjectID = "rST-ap-p0x"; */
+"rST-ap-p0x.title" = "再起動";
+
 /* Class = "NSMenu"; title = "Help"; ObjectID = "ogW-pn-jeR"; */
 "ogW-pn-jeR.title" = "ヘルプ";
 

--- a/ClashFX/ru.lproj/Main.strings
+++ b/ClashFX/ru.lproj/Main.strings
@@ -88,6 +88,9 @@
 /* Class = "NSMenuItem"; title = "Quit"; ObjectID = "NXU-86-Eem"; */
 "NXU-86-Eem.title" = "Выйти";
 
+/* Class = "NSMenuItem"; title = "Restart"; ObjectID = "rST-ap-p0x"; */
+"rST-ap-p0x.title" = "Перезапустить";
+
 /* Class = "NSMenu"; title = "Help"; ObjectID = "ogW-pn-jeR"; */
 "ogW-pn-jeR.title" = "Помощь";
 

--- a/ClashFX/zh-Hans.lproj/Main.strings
+++ b/ClashFX/zh-Hans.lproj/Main.strings
@@ -88,6 +88,9 @@
 /* Class = "NSMenuItem"; title = "Quit"; ObjectID = "NXU-86-Eem"; */
 "NXU-86-Eem.title" = "退出";
 
+/* Class = "NSMenuItem"; title = "Restart"; ObjectID = "rST-ap-p0x"; */
+"rST-ap-p0x.title" = "重启";
+
 /* Class = "NSMenu"; title = "Help"; ObjectID = "ogW-pn-jeR"; */
 "ogW-pn-jeR.title" = "帮助";
 

--- a/ClashFX/zh-Hant.lproj/Main.strings
+++ b/ClashFX/zh-Hant.lproj/Main.strings
@@ -106,6 +106,9 @@
 /* Class = "NSMenuItem"; title = "Quit"; ObjectID = "NXU-86-Eem"; */
 "NXU-86-Eem.title" = "退出";
 
+/* Class = "NSMenuItem"; title = "Restart"; ObjectID = "rST-ap-p0x"; */
+"rST-ap-p0x.title" = "重新啟動";
+
 /* Class = "NSMenu"; title = "Help"; ObjectID = "ogW-pn-jeR"; */
 "ogW-pn-jeR.title" = "幫助";
 


### PR DESCRIPTION
resolved #33

## 变更说明

在托盘状态栏菜单的「退出」菜单项上方添加了「重启」菜单项，点击后会重新启动应用程序。

## 改动内容

- **`Base.lproj/Main.storyboard`**：在「退出」菜单项上方新增「Restart」菜单项，连接到 AppDelegate 的 `actionRestart:` IBAction
- **`AppDelegate.swift`**：新增 `@IBAction func actionRestart`，调用已有的 `restartApp()` 方法实现重启逻辑
- **本地化文件**（`zh-Hans`、`zh-Hant`、`ja`、`ru` 的 `Main.strings`）：为新菜单项添加对应语言的翻译
  - 简体中文：重启
  - 繁体中文：重新啟動
  - 日语：再起動
  - 俄语：Перезапустить