### PR TITLE
feat: add tray menu item configuration in Appearance settings

### DIFF
--- a/ClashFX.xcodeproj/project.pbxproj
+++ b/ClashFX.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		4994B5542A47C4FF00E595B9 /* NormalMenuItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4994B5532A47C4FF00E595B9 /* NormalMenuItemView.swift */; };
 		78E0F1560AFD95A584F979B9 /* TrayIconPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFBA643EF41EB65C39E5574 /* TrayIconPickerView.swift */; };
 		A1B2C3D4E5F60001AA000001 /* LogoPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002AA000001 /* LogoPickerView.swift */; };
+		A1B2C3D4E5F60007AA000001 /* TrayMenuSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60008AA000001 /* TrayMenuSettingView.swift */; };
 		A1B2C3D4E5F60003AA000001 /* AppLogoTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60004AA000001 /* AppLogoTool.swift */; };
 		A1B2C3D4E5F60005AA000001 /* ImagePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60006AA000001 /* ImagePickerView.swift */; };
 		499976C821359F0400E7BF83 /* ClashWebViewContoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499976C721359F0400E7BF83 /* ClashWebViewContoller.swift */; };
@@ -251,6 +252,7 @@
 		4994B5532A47C4FF00E595B9 /* NormalMenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalMenuItemView.swift; sourceTree = "<group>"; };
 		6DFBA643EF41EB65C39E5574 /* TrayIconPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayIconPickerView.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60002AA000001 /* LogoPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoPickerView.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60008AA000001 /* TrayMenuSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayMenuSettingView.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60006AA000001 /* ImagePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePickerView.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60004AA000001 /* AppLogoTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogoTool.swift; sourceTree = "<group>"; };
 		499976C721359F0400E7BF83 /* ClashWebViewContoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClashWebViewContoller.swift; sourceTree = "<group>"; };
@@ -490,6 +492,7 @@
 				49228456270AADE20027A4B6 /* RemoteConfigUpdateIntervalSettingView.swift */,
 				4994B5532A47C4FF00E595B9 /* NormalMenuItemView.swift */,
 				A1B2C3D4E5F60002AA000001 /* LogoPickerView.swift */,
+				A1B2C3D4E5F60008AA000001 /* TrayMenuSettingView.swift */,
 				A1B2C3D4E5F60006AA000001 /* ImagePickerView.swift */,
 				6DFBA643EF41EB65C39E5574 /* TrayIconPickerView.swift */,
 			);
@@ -1079,6 +1082,7 @@
 				F976275C23634DF8000EDEFE /* LoginServiceKit.swift in Sources */,
 				4994B5542A47C4FF00E595B9 /* NormalMenuItemView.swift in Sources */,
 				A1B2C3D4E5F60001AA000001 /* LogoPickerView.swift in Sources */,
+				A1B2C3D4E5F60007AA000001 /* TrayMenuSettingView.swift in Sources */,
 				A1B2C3D4E5F60003AA000001 /* AppLogoTool.swift in Sources */,
 				A1B2C3D4E5F60005AA000001 /* ImagePickerView.swift in Sources */,
 				78E0F1560AFD95A584F979B9 /* TrayIconPickerView.swift in Sources */,

--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -50,6 +50,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet var externalControlSeparator: NSMenuItem!
     @IBOutlet var connectionsMenuItem: NSMenuItem!
 
+    // Items without existing outlets, wired via storyboard
+    @IBOutlet var benchmarkMenuItem: NSMenuItem!
+    @IBOutlet var configsMenuItem: NSMenuItem!
+    @IBOutlet var helpMenuItem: NSMenuItem!
+    @IBOutlet var aboutMenuItem: NSMenuItem!
+    @IBOutlet var showLogMenuItem: NSMenuItem!
+    @IBOutlet var portsMenuItem: NSMenuItem!
+    @IBOutlet var openConfigFolderMenuItem: NSMenuItem!
+    @IBOutlet var reloadConfigMenuItem: NSMenuItem!
+    @IBOutlet var updateExternalResourceMenuItem: NSMenuItem!
+    @IBOutlet var remoteConfigMenuItem: NSMenuItem!
+    @IBOutlet var remoteControllerMenuItem: NSMenuItem!
+
+    // Section separators
+    @IBOutlet var proxyActionsSeparator: NSMenuItem!
+    @IBOutlet var generalSettingsSeparator: NSMenuItem!
+    @IBOutlet var toolsSeparator: NSMenuItem!
+
+    // Programmatically-added items stored for visibility management
+    var langMenuItem: NSMenuItem?
+    var configEditorMenuItem: NSMenuItem?
+
     var disposeBag = DisposeBag()
     var statusItemView: StatusItemViewProtocol!
     var isSpeedTesting = false
@@ -176,6 +198,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         registCrashLogger()
         KeyboardShortCutManager.setup()
         RemoteControlManager.setupMenuItem(separator: externalControlSeparator)
+        applyTrayMenuVisibility()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onTrayMenuSettingsChanged),
+            name: .trayMenuSettingsChanged,
+            object: nil
+        )
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
@@ -1122,6 +1152,7 @@ extension AppDelegate {
 
         if let settingsIndex = statusMenu.items.firstIndex(where: { $0.action == #selector(actionMoreSetting(_:)) }) {
             statusMenu.insertItem(langItem, at: settingsIndex + 1)
+            langMenuItem = langItem
         }
     }
 
@@ -1199,6 +1230,7 @@ extension AppDelegate {
         editorItem.target = self
         if let separatorIndex = configMenu.items.firstIndex(of: configSeparatorLine) {
             configMenu.insertItem(editorItem, at: separatorIndex + 1)
+            configEditorMenuItem = editorItem
         }
     }
 
@@ -1408,5 +1440,81 @@ extension AppDelegate {
         } else if host == "update-config" {
             updateConfig()
         }
+    }
+}
+
+// MARK: Tray Menu Visibility
+
+extension AppDelegate {
+    @objc func onTrayMenuSettingsChanged() {
+        applyTrayMenuVisibility()
+    }
+
+    func applyTrayMenuVisibility() {
+        // Proxy Mode (single item)
+        proxyModeMenuItem.isHidden = !Settings.trayMenuShowProxyMode
+
+        // Node Switch: hide/show proxy group items that sit between the two separators
+        let nodeHidden = !Settings.trayMenuShowNodeSwitch
+        if let topIdx = statusMenu.items.firstIndex(of: separatorLineTop),
+           let endIdx = statusMenu.items.firstIndex(of: sepatatorLineEndProxySelect) {
+            let hasItems = endIdx > topIdx + 1
+            for i in (topIdx + 1) ..< endIdx {
+                statusMenu.items[i].isHidden = nodeHidden
+            }
+            sepatatorLineEndProxySelect.isHidden = !hasItems || nodeHidden
+        }
+
+        // Proxy Actions group
+        let showProxyActions = Settings.trayMenuShowProxyActions
+        proxySettingMenuItem.isHidden = !(showProxyActions && Settings.trayMenuShowSystemProxy)
+        enhancedModeMenuItem.isHidden = !(showProxyActions && Settings.trayMenuShowEnhancedMode)
+        let showCopy = showProxyActions && Settings.trayMenuShowCopyShellCmd
+        copyExportCommandMenuItem.isHidden = !showCopy
+        copyExportCommandExternalMenuItem.isHidden = !showCopy
+        let anyProxyAction = showProxyActions && (Settings.trayMenuShowSystemProxy || Settings.trayMenuShowEnhancedMode || Settings.trayMenuShowCopyShellCmd)
+        proxyActionsSeparator.isHidden = !anyProxyAction
+
+        // General Settings group
+        let showGeneral = Settings.trayMenuShowGeneralSettings
+        autoStartMenuItem.isHidden = !(showGeneral && Settings.trayMenuShowStartAtLogin)
+        showNetSpeedIndicatorMenuItem.isHidden = !(showGeneral && Settings.trayMenuShowNetSpeed)
+        allowFromLanMenuItem.isHidden = !(showGeneral && Settings.trayMenuShowAllowLan)
+        let anyGeneral = showGeneral && (Settings.trayMenuShowStartAtLogin || Settings.trayMenuShowNetSpeed || Settings.trayMenuShowAllowLan)
+        generalSettingsSeparator.isHidden = !anyGeneral
+
+        // Tools group
+        let showTools = Settings.trayMenuShowTools
+        benchmarkMenuItem.isHidden = !(showTools && Settings.trayMenuShowBenchmark)
+        if #available(macOS 10.15, *) {
+            dashboardMenuItem.isHidden = !(showTools && Settings.trayMenuShowDashboard)
+            connectionsMenuItem.isHidden = !(showTools && Settings.trayMenuShowConnections)
+            let anyTools = showTools && (Settings.trayMenuShowBenchmark || Settings.trayMenuShowDashboard || Settings.trayMenuShowConnections)
+            toolsSeparator.isHidden = !anyTools
+        } else {
+            toolsSeparator.isHidden = !(showTools && Settings.trayMenuShowBenchmark)
+        }
+
+        // Configs group
+        let showConfigs = Settings.trayMenuShowConfigs
+        configsMenuItem.isHidden = !showConfigs
+        configEditorMenuItem?.isHidden = !(showConfigs && Settings.trayMenuShowConfigEditor)
+        openConfigFolderMenuItem.isHidden = !(showConfigs && Settings.trayMenuShowOpenConfigFolder)
+        reloadConfigMenuItem.isHidden = !(showConfigs && Settings.trayMenuShowReloadConfig)
+        updateExternalResourceMenuItem.isHidden = !(showConfigs && Settings.trayMenuShowUpdateExternal)
+        remoteConfigMenuItem.isHidden = !(showConfigs && Settings.trayMenuShowRemoteConfig)
+        remoteControllerMenuItem.isHidden = !(showConfigs && Settings.trayMenuShowRemoteController)
+
+        // Language (single item, added dynamically)
+        langMenuItem?.isHidden = !Settings.trayMenuShowLanguage
+
+        // Help group
+        let showHelp = Settings.trayMenuShowHelp
+        helpMenuItem.isHidden = !showHelp
+        aboutMenuItem.isHidden = !(showHelp && Settings.trayMenuShowAbout)
+        checkForUpdateMenuItem.isHidden = !(showHelp && Settings.trayMenuShowCheckUpdate)
+        logLevelMenuItem.isHidden = !(showHelp && Settings.trayMenuShowLogLevel)
+        showLogMenuItem.isHidden = !(showHelp && Settings.trayMenuShowShowLog)
+        portsMenuItem.isHidden = !(showHelp && Settings.trayMenuShowPorts)
     }
 }

--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -450,7 +450,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func updateProxyList(withMenus menus: [NSMenuItem]) {
         guard !menus.isEmpty else { return }
         let startIndex = statusMenu.items.firstIndex(of: separatorLineTop)! + 1
-        let endIndex = statusMenu.items.firstIndex(of: sepatatorLineEndProxySelect)!
         sepatatorLineEndProxySelect.isHidden = false
         for each in menus {
             statusMenu.insertItem(each, at: startIndex)

--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -473,6 +473,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             for item in items.reversed() {
                 menu.insertItem(item, at: 0)
             }
+            // Apply config-switcher visibility to newly inserted items
+            self.applyConfigSwitcherVisibility(
+                showConfigSwitcher: Settings.trayMenuShowConfigs && Settings.trayMenuShowConfigSwitcher
+            )
         }
     }
 
@@ -1450,6 +1454,16 @@ extension AppDelegate {
         applyTrayMenuVisibility()
     }
 
+    /// Hides or shows dynamic config-switch items and the separator that follows them.
+    private func applyConfigSwitcherVisibility(showConfigSwitcher: Bool) {
+        guard let menu = configSeparatorLine.menu,
+              let lineIndex = menu.items.firstIndex(of: configSeparatorLine) else { return }
+        for i in 0 ..< lineIndex {
+            menu.items[i].isHidden = !showConfigSwitcher
+        }
+        configSeparatorLine.isHidden = !showConfigSwitcher || lineIndex == 0
+    }
+
     func applyTrayMenuVisibility() {
         // Proxy Mode (single item)
         proxyModeMenuItem.isHidden = !Settings.trayMenuShowProxyMode
@@ -1504,6 +1518,9 @@ extension AppDelegate {
         updateExternalResourceMenuItem.isHidden = !(showConfigs && Settings.trayMenuShowUpdateExternal)
         remoteConfigMenuItem.isHidden = !(showConfigs && Settings.trayMenuShowRemoteConfig)
         remoteControllerMenuItem.isHidden = !(showConfigs && Settings.trayMenuShowRemoteController)
+
+        // Dynamic config switch items (at top of Configs submenu, before configSeparatorLine)
+        applyConfigSwitcherVisibility(showConfigSwitcher: showConfigs && Settings.trayMenuShowConfigSwitcher)
 
         // Language (single item, added dynamically)
         langMenuItem?.isHidden = !Settings.trayMenuShowLanguage

--- a/ClashFX/Base.lproj/Main.storyboard
+++ b/ClashFX/Base.lproj/Main.storyboard
@@ -786,6 +786,20 @@
                         <outlet property="showNetSpeedIndicatorMenuItem" destination="YIO-Vj-64f" id="9a5-3N-Ylk"/>
                         <outlet property="socksPortMenuItem" destination="Uy1-g8-r6Q" id="NiI-Gy-9Sa"/>
                         <outlet property="statusMenu" destination="Afa-lD-EbR" id="cov-E9-WrO"/>
+                        <outlet property="benchmarkMenuItem" destination="COu-UX-bww" id="tmx-BM-bw1"/>
+                        <outlet property="configsMenuItem" destination="JMV-Dy-CI0" id="cfg-MI-mn1"/>
+                        <outlet property="helpMenuItem" destination="Dd9-2F-FVY" id="hlp-MI-mn1"/>
+                        <outlet property="aboutMenuItem" destination="hUb-k9-TEf" id="abt-MI-mn1"/>
+                        <outlet property="showLogMenuItem" destination="xxZ-9l-69m" id="slg-MI-mn1"/>
+                        <outlet property="portsMenuItem" destination="9i0-LH-x04" id="pts-MI-mn1"/>
+                        <outlet property="openConfigFolderMenuItem" destination="DwE-WX-ETZ" id="ocf-MI-mn1"/>
+                        <outlet property="reloadConfigMenuItem" destination="q3G-VH-eyy" id="rlc-MI-mn1"/>
+                        <outlet property="updateExternalResourceMenuItem" destination="9g1-lW-mA8" id="uer-MI-mn1"/>
+                        <outlet property="remoteConfigMenuItem" destination="h1C-R6-Y9w" id="rmc-MI-mn1"/>
+                        <outlet property="remoteControllerMenuItem" destination="BRR-WK-aeP" id="rct-MI-mn1"/>
+                        <outlet property="proxyActionsSeparator" destination="nXl-3B-Q18" id="pas-SP-mn1"/>
+                        <outlet property="generalSettingsSeparator" destination="HZ7-Hd-kA2" id="gss-SP-mn1"/>
+                        <outlet property="toolsSeparator" destination="UpD-DI-Smv" id="tls-SP-mn1"/>
                     </connections>
                 </customObject>
                 <menu id="Afa-lD-EbR">

--- a/ClashFX/General/Managers/MenuItemFactory.swift
+++ b/ClashFX/General/Managers/MenuItemFactory.swift
@@ -96,12 +96,14 @@ class MenuItemFactory {
         let app = AppDelegate.shared
         let startIndex = app.statusMenu.items.firstIndex(of: app.separatorLineTop)! + 1
         let endIndex = app.statusMenu.items.firstIndex(of: app.sepatatorLineEndProxySelect)!
-        app.sepatatorLineEndProxySelect.isHidden = menus.isEmpty
+        let nodeHidden = !Settings.trayMenuShowNodeSwitch
+        app.sepatatorLineEndProxySelect.isHidden = menus.isEmpty || nodeHidden
         for _ in 0 ..< endIndex - startIndex {
             app.statusMenu.removeItem(at: startIndex)
         }
         for each in menus {
             app.statusMenu.insertItem(each, at: startIndex)
+            each.isHidden = nodeHidden
         }
     }
 

--- a/ClashFX/General/Managers/Settings.swift
+++ b/ClashFX/General/Managers/Settings.swift
@@ -93,4 +93,96 @@ enum Settings {
 
     @UserDefault("appLanguage", defaultValue: "")
     static var appLanguage: String
+
+    // MARK: - Tray Menu Visibility
+
+    @UserDefault("trayMenuShowProxyMode", defaultValue: true)
+    static var trayMenuShowProxyMode: Bool
+
+    @UserDefault("trayMenuShowNodeSwitch", defaultValue: true)
+    static var trayMenuShowNodeSwitch: Bool
+
+    // Proxy Actions group
+    @UserDefault("trayMenuShowProxyActions", defaultValue: true)
+    static var trayMenuShowProxyActions: Bool
+
+    @UserDefault("trayMenuShowSystemProxy", defaultValue: true)
+    static var trayMenuShowSystemProxy: Bool
+
+    @UserDefault("trayMenuShowEnhancedMode", defaultValue: true)
+    static var trayMenuShowEnhancedMode: Bool
+
+    @UserDefault("trayMenuShowCopyShellCmd", defaultValue: true)
+    static var trayMenuShowCopyShellCmd: Bool
+
+    // General Settings group
+    @UserDefault("trayMenuShowGeneralSettings", defaultValue: true)
+    static var trayMenuShowGeneralSettings: Bool
+
+    @UserDefault("trayMenuShowStartAtLogin", defaultValue: true)
+    static var trayMenuShowStartAtLogin: Bool
+
+    @UserDefault("trayMenuShowNetSpeed", defaultValue: true)
+    static var trayMenuShowNetSpeed: Bool
+
+    @UserDefault("trayMenuShowAllowLan", defaultValue: true)
+    static var trayMenuShowAllowLan: Bool
+
+    // Tools group
+    @UserDefault("trayMenuShowTools", defaultValue: true)
+    static var trayMenuShowTools: Bool
+
+    @UserDefault("trayMenuShowBenchmark", defaultValue: true)
+    static var trayMenuShowBenchmark: Bool
+
+    @UserDefault("trayMenuShowDashboard", defaultValue: true)
+    static var trayMenuShowDashboard: Bool
+
+    @UserDefault("trayMenuShowConnections", defaultValue: true)
+    static var trayMenuShowConnections: Bool
+
+    // Configs group
+    @UserDefault("trayMenuShowConfigs", defaultValue: true)
+    static var trayMenuShowConfigs: Bool
+
+    @UserDefault("trayMenuShowConfigEditor", defaultValue: true)
+    static var trayMenuShowConfigEditor: Bool
+
+    @UserDefault("trayMenuShowOpenConfigFolder", defaultValue: true)
+    static var trayMenuShowOpenConfigFolder: Bool
+
+    @UserDefault("trayMenuShowReloadConfig", defaultValue: true)
+    static var trayMenuShowReloadConfig: Bool
+
+    @UserDefault("trayMenuShowUpdateExternal", defaultValue: true)
+    static var trayMenuShowUpdateExternal: Bool
+
+    @UserDefault("trayMenuShowRemoteConfig", defaultValue: true)
+    static var trayMenuShowRemoteConfig: Bool
+
+    @UserDefault("trayMenuShowRemoteController", defaultValue: true)
+    static var trayMenuShowRemoteController: Bool
+
+    // Language (single toggle)
+    @UserDefault("trayMenuShowLanguage", defaultValue: true)
+    static var trayMenuShowLanguage: Bool
+
+    // Help group
+    @UserDefault("trayMenuShowHelp", defaultValue: true)
+    static var trayMenuShowHelp: Bool
+
+    @UserDefault("trayMenuShowAbout", defaultValue: true)
+    static var trayMenuShowAbout: Bool
+
+    @UserDefault("trayMenuShowCheckUpdate", defaultValue: true)
+    static var trayMenuShowCheckUpdate: Bool
+
+    @UserDefault("trayMenuShowLogLevel", defaultValue: true)
+    static var trayMenuShowLogLevel: Bool
+
+    @UserDefault("trayMenuShowShowLog", defaultValue: true)
+    static var trayMenuShowShowLog: Bool
+
+    @UserDefault("trayMenuShowPorts", defaultValue: true)
+    static var trayMenuShowPorts: Bool
 }

--- a/ClashFX/General/Managers/Settings.swift
+++ b/ClashFX/General/Managers/Settings.swift
@@ -145,6 +145,9 @@ enum Settings {
     @UserDefault("trayMenuShowConfigs", defaultValue: true)
     static var trayMenuShowConfigs: Bool
 
+    @UserDefault("trayMenuShowConfigSwitcher", defaultValue: true)
+    static var trayMenuShowConfigSwitcher: Bool
+
     @UserDefault("trayMenuShowConfigEditor", defaultValue: true)
     static var trayMenuShowConfigEditor: Bool
 

--- a/ClashFX/Macro/Notification.swift
+++ b/ClashFX/Macro/Notification.swift
@@ -18,4 +18,6 @@ extension Notification.Name {
     static func proxyUpdate(for name: ClashProxyName) -> Notification.Name {
         return Notification.Name("kProxyUpdate_\(name)")
     }
+
+    static let trayMenuSettingsChanged = Notification.Name("kTrayMenuSettingsChanged")
 }

--- a/ClashFX/Support Files/en.lproj/Localizable.strings
+++ b/ClashFX/Support Files/en.lproj/Localizable.strings
@@ -414,3 +414,69 @@
 
 /* No comment provided by engineer. */
 "Drag and drop an image to customize the app icon.\nRecommended: 512x512 px (1024x1024 for @2x), PNG or ICNS format." = "Drag and drop an image to customize the app icon.\nRecommended: 512x512 px (1024x1024 for @2x), PNG or ICNS format.";
+
+/* Tray Menu Settings */
+"Tray Menu" = "Tray Menu";
+
+/* No comment provided by engineer. */
+"Node Switch" = "Node Switch";
+
+/* No comment provided by engineer. */
+"Proxy Actions" = "Proxy Actions";
+
+/* No comment provided by engineer. */
+"General Settings" = "General Settings";
+
+/* No comment provided by engineer. */
+"Tools" = "Tools";
+
+/* No comment provided by engineer. */
+"Start at Login" = "Start at Login";
+
+/* No comment provided by engineer. */
+"Dashboard" = "Dashboard";
+
+/* No comment provided by engineer. */
+"Connection Details" = "Connection Details";
+
+/* No comment provided by engineer. */
+"Configs" = "Configs";
+
+/* No comment provided by engineer. */
+"Open Config Folder" = "Open Config Folder";
+
+/* No comment provided by engineer. */
+"Reload Config" = "Reload Config";
+
+/* No comment provided by engineer. */
+"Update External Resources" = "Update External Resources";
+
+/* No comment provided by engineer. */
+"Remote Config" = "Remote Config";
+
+/* No comment provided by engineer. */
+"Remote Controller" = "Remote Controller";
+
+/* No comment provided by engineer. */
+"Help" = "Help";
+
+/* No comment provided by engineer. */
+"About" = "About";
+
+/* No comment provided by engineer. */
+"Check for Update" = "Check for Update";
+
+/* No comment provided by engineer. */
+"Log Level" = "Log Level";
+
+/* No comment provided by engineer. */
+"Show Log" = "Show Log";
+
+/* No comment provided by engineer. */
+"Ports" = "Ports";
+
+/* No comment provided by engineer. */
+"Show Net Speed" = "Show Net Speed";
+
+/* No comment provided by engineer. */
+"Allow from LAN" = "Allow from LAN";

--- a/ClashFX/Support Files/en.lproj/Localizable.strings
+++ b/ClashFX/Support Files/en.lproj/Localizable.strings
@@ -480,3 +480,6 @@
 
 /* No comment provided by engineer. */
 "Allow from LAN" = "Allow from LAN";
+
+/* No comment provided by engineer. */
+"Config Switcher" = "Config Switcher";

--- a/ClashFX/Support Files/ja.lproj/Localizable.strings
+++ b/ClashFX/Support Files/ja.lproj/Localizable.strings
@@ -414,3 +414,72 @@
 
 /* No comment provided by engineer. */
 "Drag and drop an image to customize the app icon.\nRecommended: 512x512 px (1024x1024 for @2x), PNG or ICNS format." = "画像をドラッグ＆ドロップしてアプリアイコンをカスタマイズ。\n推奨：512×512 px（@2x は 1024×1024）、PNG または ICNS 形式。";
+
+/* Tray Menu Settings */
+"Tray Menu" = "トレイメニュー";
+
+/* No comment provided by engineer. */
+"Node Switch" = "ノード切替";
+
+/* No comment provided by engineer. */
+"Proxy Actions" = "プロキシ操作";
+
+/* No comment provided by engineer. */
+"General Settings" = "一般設定";
+
+/* No comment provided by engineer. */
+"Tools" = "ツール";
+
+/* No comment provided by engineer. */
+"Start at Login" = "ログイン時に起動";
+
+/* No comment provided by engineer. */
+"Dashboard" = "ダッシュボード";
+
+/* No comment provided by engineer. */
+"Connection Details" = "接続の詳細";
+
+/* No comment provided by engineer. */
+"Configs" = "設定";
+
+/* No comment provided by engineer. */
+"Open Config Folder" = "設定フォルダを開く";
+
+/* No comment provided by engineer. */
+"Reload Config" = "設定を再読み込み";
+
+/* No comment provided by engineer. */
+"Update External Resources" = "外部リソースを更新";
+
+/* No comment provided by engineer. */
+"Remote Config" = "リモート設定";
+
+/* No comment provided by engineer. */
+"Remote Controller" = "リモートコントローラー";
+
+/* No comment provided by engineer. */
+"Config Switcher" = "設定切替";
+
+/* No comment provided by engineer. */
+"Help" = "ヘルプ";
+
+/* No comment provided by engineer. */
+"About" = "このアプリについて";
+
+/* No comment provided by engineer. */
+"Check for Update" = "アップデートを確認";
+
+/* No comment provided by engineer. */
+"Log Level" = "ログレベル";
+
+/* No comment provided by engineer. */
+"Show Log" = "ログを表示";
+
+/* No comment provided by engineer. */
+"Ports" = "ポート";
+
+/* No comment provided by engineer. */
+"Show Net Speed" = "ネット速度を表示";
+
+/* No comment provided by engineer. */
+"Allow from LAN" = "LAN からの接続を許可";

--- a/ClashFX/Support Files/ru.lproj/Localizable.strings
+++ b/ClashFX/Support Files/ru.lproj/Localizable.strings
@@ -414,3 +414,72 @@
 
 /* No comment provided by engineer. */
 "Drag and drop an image to customize the app icon.\nRecommended: 512x512 px (1024x1024 for @2x), PNG or ICNS format." = "Перетащите изображение для настройки иконки приложения.\nРекомендуется: 512×512 пикс. (@2x — 1024×1024), формат PNG или ICNS.";
+
+/* Tray Menu Settings */
+"Tray Menu" = "Меню трея";
+
+/* No comment provided by engineer. */
+"Node Switch" = "Переключение узла";
+
+/* No comment provided by engineer. */
+"Proxy Actions" = "Действия прокси";
+
+/* No comment provided by engineer. */
+"General Settings" = "Основные настройки";
+
+/* No comment provided by engineer. */
+"Tools" = "Инструменты";
+
+/* No comment provided by engineer. */
+"Start at Login" = "Запускать при входе";
+
+/* No comment provided by engineer. */
+"Dashboard" = "Панель управления";
+
+/* No comment provided by engineer. */
+"Connection Details" = "Сведения о соединении";
+
+/* No comment provided by engineer. */
+"Configs" = "Конфигурации";
+
+/* No comment provided by engineer. */
+"Open Config Folder" = "Открыть папку конфигурации";
+
+/* No comment provided by engineer. */
+"Reload Config" = "Перезагрузить конфигурацию";
+
+/* No comment provided by engineer. */
+"Update External Resources" = "Обновить внешние ресурсы";
+
+/* No comment provided by engineer. */
+"Remote Config" = "Удалённая конфигурация";
+
+/* No comment provided by engineer. */
+"Remote Controller" = "Удалённый контроллер";
+
+/* No comment provided by engineer. */
+"Config Switcher" = "Переключатель конфигураций";
+
+/* No comment provided by engineer. */
+"Help" = "Справка";
+
+/* No comment provided by engineer. */
+"About" = "О программе";
+
+/* No comment provided by engineer. */
+"Check for Update" = "Проверить наличие обновлений";
+
+/* No comment provided by engineer. */
+"Log Level" = "Уровень журнала";
+
+/* No comment provided by engineer. */
+"Show Log" = "Показать журнал";
+
+/* No comment provided by engineer. */
+"Ports" = "Порты";
+
+/* No comment provided by engineer. */
+"Show Net Speed" = "Показать скорость сети";
+
+/* No comment provided by engineer. */
+"Allow from LAN" = "Разрешить из локальной сети";

--- a/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
@@ -451,3 +451,69 @@
 
 /* No comment provided by engineer. */
 "Drag and drop an image to customize the app icon.\nRecommended: 512x512 px (1024x1024 for @2x), PNG or ICNS format." = "拖拽图片到此处自定义应用图标。\n建议尺寸：512×512 像素（@2x 为 1024×1024），PNG 或 ICNS 格式。";
+
+/* Tray Menu Settings */
+"Tray Menu" = "托盘菜单";
+
+/* No comment provided by engineer. */
+"Node Switch" = "节点切换";
+
+/* No comment provided by engineer. */
+"Proxy Actions" = "代理控制";
+
+/* No comment provided by engineer. */
+"General Settings" = "通用设置";
+
+/* No comment provided by engineer. */
+"Tools" = "工具";
+
+/* No comment provided by engineer. */
+"Start at Login" = "开机启动";
+
+/* No comment provided by engineer. */
+"Dashboard" = "控制台";
+
+/* No comment provided by engineer. */
+"Connection Details" = "连接查看器";
+
+/* No comment provided by engineer. */
+"Configs" = "配置";
+
+/* No comment provided by engineer. */
+"Open Config Folder" = "打开配置文件夹";
+
+/* No comment provided by engineer. */
+"Reload Config" = "重载配置文件";
+
+/* No comment provided by engineer. */
+"Update External Resources" = "更新外部资源";
+
+/* No comment provided by engineer. */
+"Remote Config" = "托管配置";
+
+/* No comment provided by engineer. */
+"Remote Controller" = "远程控制器";
+
+/* No comment provided by engineer. */
+"Help" = "帮助";
+
+/* No comment provided by engineer. */
+"About" = "关于";
+
+/* No comment provided by engineer. */
+"Check for Update" = "检查更新";
+
+/* No comment provided by engineer. */
+"Log Level" = "日志等级";
+
+/* No comment provided by engineer. */
+"Show Log" = "显示日志";
+
+/* No comment provided by engineer. */
+"Ports" = "端口";
+
+/* No comment provided by engineer. */
+"Show Net Speed" = "显示实时速率";
+
+/* No comment provided by engineer. */
+"Allow from LAN" = "允许局域网连接";

--- a/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
@@ -517,3 +517,6 @@
 
 /* No comment provided by engineer. */
 "Allow from LAN" = "允许局域网连接";
+
+/* No comment provided by engineer. */
+"Config Switcher" = "配置切换";

--- a/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
@@ -414,3 +414,69 @@
 
 /* No comment provided by engineer. */
 "Drag and drop an image to customize the app icon.\nRecommended: 512x512 px (1024x1024 for @2x), PNG or ICNS format." = "拖曳圖片到此處自訂應用圖示。\n建議尺寸：512×512 像素（@2x 為 1024×1024），PNG 或 ICNS 格式。";
+
+/* Tray Menu Settings */
+"Tray Menu" = "托盤選單";
+
+/* No comment provided by engineer. */
+"Node Switch" = "節點切換";
+
+/* No comment provided by engineer. */
+"Proxy Actions" = "代理控制";
+
+/* No comment provided by engineer. */
+"General Settings" = "通用設定";
+
+/* No comment provided by engineer. */
+"Tools" = "工具";
+
+/* No comment provided by engineer. */
+"Start at Login" = "登入時啟動";
+
+/* No comment provided by engineer. */
+"Dashboard" = "控制台";
+
+/* No comment provided by engineer. */
+"Connection Details" = "連接檢視器";
+
+/* No comment provided by engineer. */
+"Configs" = "配置";
+
+/* No comment provided by engineer. */
+"Open Config Folder" = "開啟配置資料夾";
+
+/* No comment provided by engineer. */
+"Reload Config" = "重載配置文件";
+
+/* No comment provided by engineer. */
+"Update External Resources" = "更新外部資源";
+
+/* No comment provided by engineer. */
+"Remote Config" = "託管配置";
+
+/* No comment provided by engineer. */
+"Remote Controller" = "遠端控制器";
+
+/* No comment provided by engineer. */
+"Help" = "輔助說明";
+
+/* No comment provided by engineer. */
+"About" = "關於";
+
+/* No comment provided by engineer. */
+"Check for Update" = "檢查更新";
+
+/* No comment provided by engineer. */
+"Log Level" = "日誌等級";
+
+/* No comment provided by engineer. */
+"Show Log" = "顯示日誌";
+
+/* No comment provided by engineer. */
+"Ports" = "端口";
+
+/* No comment provided by engineer. */
+"Show Net Speed" = "顯示即時速率";
+
+/* No comment provided by engineer. */
+"Allow from LAN" = "允許區域網路連線";

--- a/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
@@ -480,3 +480,6 @@
 
 /* No comment provided by engineer. */
 "Allow from LAN" = "允許區域網路連線";
+
+/* No comment provided by engineer. */
+"Config Switcher" = "配置切換";

--- a/ClashFX/ViewControllers/Settings/AppearanceSettingViewController.swift
+++ b/ClashFX/ViewControllers/Settings/AppearanceSettingViewController.swift
@@ -9,6 +9,7 @@ import Cocoa
 
 class AppearanceSettingViewController: NSViewController {
     private var didComputePreferredSize = false
+    private let trayMenuSettingViewHeight: CGFloat = 300
 
     override func loadView() {
         let width: CGFloat = 400
@@ -47,8 +48,26 @@ class AppearanceSettingViewController: NSViewController {
             ])
         }
 
+        let menuBox = NSBox()
+        menuBox.translatesAutoresizingMaskIntoConstraints = false
+        menuBox.title = NSLocalizedString("Tray Menu", comment: "")
+
+        let menuSettingView = TrayMenuSettingView()
+        menuBox.contentView?.addSubview(menuSettingView)
+
+        if let cv = menuBox.contentView {
+            NSLayoutConstraint.activate([
+                menuSettingView.topAnchor.constraint(equalTo: cv.topAnchor, constant: 8),
+                menuSettingView.leadingAnchor.constraint(equalTo: cv.leadingAnchor, constant: 8),
+                menuSettingView.trailingAnchor.constraint(equalTo: cv.trailingAnchor, constant: -8),
+                menuSettingView.heightAnchor.constraint(equalToConstant: trayMenuSettingViewHeight),
+                cv.bottomAnchor.constraint(equalTo: menuSettingView.bottomAnchor, constant: 8),
+            ])
+        }
+
         contentView.addSubview(trayBox)
         contentView.addSubview(logoBox)
+        contentView.addSubview(menuBox)
 
         NSLayoutConstraint.activate([
             trayBox.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 30),
@@ -59,7 +78,11 @@ class AppearanceSettingViewController: NSViewController {
             logoBox.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
             logoBox.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
 
-            contentView.bottomAnchor.constraint(greaterThanOrEqualTo: logoBox.bottomAnchor, constant: 20)
+            menuBox.topAnchor.constraint(equalTo: logoBox.bottomAnchor, constant: 12),
+            menuBox.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            menuBox.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+
+            contentView.bottomAnchor.constraint(greaterThanOrEqualTo: menuBox.bottomAnchor, constant: 20)
         ])
 
         view = contentView
@@ -85,3 +108,4 @@ class AppearanceSettingViewController: NSViewController {
         }
     }
 }
+

--- a/ClashFX/Views/TrayMenuSettingView.swift
+++ b/ClashFX/Views/TrayMenuSettingView.swift
@@ -1,0 +1,287 @@
+//
+//  TrayMenuSettingView.swift
+//  ClashFX
+//
+
+import Cocoa
+
+class TrayMenuSettingView: NSView {
+
+    // MARK: - Data model
+
+    private struct ItemRow {
+        let title: String
+        let getter: () -> Bool
+        let setter: (Bool) -> Void
+    }
+
+    private struct Group {
+        let title: String
+        let getter: () -> Bool
+        let setter: (Bool) -> Void
+        let children: [ItemRow]
+    }
+
+    private enum SectionEntry {
+        case single(ItemRow)
+        case group(Group)
+    }
+
+    private struct ChildView {
+        let label: NSTextField
+        let control: NSControl
+    }
+
+    // MARK: - State
+
+    private var switchHandlers: [NSControl: () -> Void] = [:]
+    private var parentControlToChildren: [NSControl: [ChildView]] = [:]
+    private var uiSetupDone = false
+
+    // MARK: - Init
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+
+    // MARK: - Data
+
+    private func sections() -> [SectionEntry] {
+        return [
+            .single(ItemRow(
+                title: NSLocalizedString("Proxy Mode", comment: ""),
+                getter: { Settings.trayMenuShowProxyMode },
+                setter: { Settings.trayMenuShowProxyMode = $0 }
+            )),
+            .single(ItemRow(
+                title: NSLocalizedString("Node Switch", comment: ""),
+                getter: { Settings.trayMenuShowNodeSwitch },
+                setter: { Settings.trayMenuShowNodeSwitch = $0 }
+            )),
+            .group(Group(
+                title: NSLocalizedString("Proxy Actions", comment: ""),
+                getter: { Settings.trayMenuShowProxyActions },
+                setter: { Settings.trayMenuShowProxyActions = $0 },
+                children: [
+                    ItemRow(title: NSLocalizedString("System Proxy", comment: ""), getter: { Settings.trayMenuShowSystemProxy }, setter: { Settings.trayMenuShowSystemProxy = $0 }),
+                    ItemRow(title: NSLocalizedString("Enhanced Mode", comment: ""), getter: { Settings.trayMenuShowEnhancedMode }, setter: { Settings.trayMenuShowEnhancedMode = $0 }),
+                    ItemRow(title: NSLocalizedString("Copy Shell Command", comment: ""), getter: { Settings.trayMenuShowCopyShellCmd }, setter: { Settings.trayMenuShowCopyShellCmd = $0 }),
+                ]
+            )),
+            .group(Group(
+                title: NSLocalizedString("General Settings", comment: ""),
+                getter: { Settings.trayMenuShowGeneralSettings },
+                setter: { Settings.trayMenuShowGeneralSettings = $0 },
+                children: [
+                    ItemRow(title: NSLocalizedString("Start at Login", comment: ""), getter: { Settings.trayMenuShowStartAtLogin }, setter: { Settings.trayMenuShowStartAtLogin = $0 }),
+                    ItemRow(title: NSLocalizedString("Show Net Speed", comment: ""), getter: { Settings.trayMenuShowNetSpeed }, setter: { Settings.trayMenuShowNetSpeed = $0 }),
+                    ItemRow(title: NSLocalizedString("Allow from LAN", comment: ""), getter: { Settings.trayMenuShowAllowLan }, setter: { Settings.trayMenuShowAllowLan = $0 }),
+                ]
+            )),
+            .group(Group(
+                title: NSLocalizedString("Tools", comment: ""),
+                getter: { Settings.trayMenuShowTools },
+                setter: { Settings.trayMenuShowTools = $0 },
+                children: [
+                    ItemRow(title: NSLocalizedString("Benchmark", comment: ""), getter: { Settings.trayMenuShowBenchmark }, setter: { Settings.trayMenuShowBenchmark = $0 }),
+                    ItemRow(title: NSLocalizedString("Dashboard", comment: ""), getter: { Settings.trayMenuShowDashboard }, setter: { Settings.trayMenuShowDashboard = $0 }),
+                    ItemRow(title: NSLocalizedString("Connection Details", comment: ""), getter: { Settings.trayMenuShowConnections }, setter: { Settings.trayMenuShowConnections = $0 }),
+                ]
+            )),
+            .group(Group(
+                title: NSLocalizedString("Configs", comment: ""),
+                getter: { Settings.trayMenuShowConfigs },
+                setter: { Settings.trayMenuShowConfigs = $0 },
+                children: [
+                    ItemRow(title: NSLocalizedString("Config Editor", comment: ""), getter: { Settings.trayMenuShowConfigEditor }, setter: { Settings.trayMenuShowConfigEditor = $0 }),
+                    ItemRow(title: NSLocalizedString("Open Config Folder", comment: ""), getter: { Settings.trayMenuShowOpenConfigFolder }, setter: { Settings.trayMenuShowOpenConfigFolder = $0 }),
+                    ItemRow(title: NSLocalizedString("Reload Config", comment: ""), getter: { Settings.trayMenuShowReloadConfig }, setter: { Settings.trayMenuShowReloadConfig = $0 }),
+                    ItemRow(title: NSLocalizedString("Update External Resources", comment: ""), getter: { Settings.trayMenuShowUpdateExternal }, setter: { Settings.trayMenuShowUpdateExternal = $0 }),
+                    ItemRow(title: NSLocalizedString("Remote Config", comment: ""), getter: { Settings.trayMenuShowRemoteConfig }, setter: { Settings.trayMenuShowRemoteConfig = $0 }),
+                    ItemRow(title: NSLocalizedString("Remote Controller", comment: ""), getter: { Settings.trayMenuShowRemoteController }, setter: { Settings.trayMenuShowRemoteController = $0 }),
+                ]
+            )),
+            .single(ItemRow(
+                title: NSLocalizedString("Language", comment: ""),
+                getter: { Settings.trayMenuShowLanguage },
+                setter: { Settings.trayMenuShowLanguage = $0 }
+            )),
+            .group(Group(
+                title: NSLocalizedString("Help", comment: ""),
+                getter: { Settings.trayMenuShowHelp },
+                setter: { Settings.trayMenuShowHelp = $0 },
+                children: [
+                    ItemRow(title: NSLocalizedString("About", comment: ""), getter: { Settings.trayMenuShowAbout }, setter: { Settings.trayMenuShowAbout = $0 }),
+                    ItemRow(title: NSLocalizedString("Check for Update", comment: ""), getter: { Settings.trayMenuShowCheckUpdate }, setter: { Settings.trayMenuShowCheckUpdate = $0 }),
+                    ItemRow(title: NSLocalizedString("Log Level", comment: ""), getter: { Settings.trayMenuShowLogLevel }, setter: { Settings.trayMenuShowLogLevel = $0 }),
+                    ItemRow(title: NSLocalizedString("Show Log", comment: ""), getter: { Settings.trayMenuShowShowLog }, setter: { Settings.trayMenuShowShowLog = $0 }),
+                    ItemRow(title: NSLocalizedString("Ports", comment: ""), getter: { Settings.trayMenuShowPorts }, setter: { Settings.trayMenuShowPorts = $0 }),
+                ]
+            )),
+        ]
+    }
+
+    // MARK: - UI Setup
+
+    private func setupUI() {
+        guard !uiSetupDone else { return }
+        uiSetupDone = true
+        translatesAutoresizingMaskIntoConstraints = false
+
+        let scrollView = NSScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        addSubview(scrollView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        let stack = NSStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.orientation = .vertical
+        stack.alignment = .fill
+        stack.spacing = 0
+        stack.edgeInsets = NSEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
+
+        scrollView.documentView = stack
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: scrollView.contentView.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: scrollView.contentView.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: scrollView.contentView.trailingAnchor),
+        ])
+
+        buildRows(into: stack)
+    }
+
+    private func buildRows(into stack: NSStackView) {
+        let allSections = sections()
+        for (idx, entry) in allSections.enumerated() {
+            switch entry {
+            case .single(let row):
+                let (rowView, control, _) = makeRow(title: row.title, isOn: row.getter())
+                switchHandlers[control] = { [weak control, row] in
+                    guard let c = control else { return }
+                    row.setter(c.state == .on)
+                    NotificationCenter.default.post(name: .trayMenuSettingsChanged, object: nil)
+                }
+                stack.addArrangedSubview(rowView)
+
+            case .group(let group):
+                let (parentRowView, parentControl, _) = makeRow(
+                    title: group.title, isOn: group.getter(), bold: true
+                )
+                stack.addArrangedSubview(parentRowView)
+
+                let parentIsOn = group.getter()
+                var childViews: [ChildView] = []
+
+                for child in group.children {
+                    let (childRowView, childControl, childLabel) = makeRow(
+                        title: child.title, isOn: child.getter(),
+                        indent: 16, parentOn: parentIsOn
+                    )
+                    switchHandlers[childControl] = { [weak childControl, child] in
+                        guard let c = childControl else { return }
+                        child.setter(c.state == .on)
+                        NotificationCenter.default.post(name: .trayMenuSettingsChanged, object: nil)
+                    }
+                    childViews.append(ChildView(label: childLabel, control: childControl))
+                    stack.addArrangedSubview(childRowView)
+                }
+
+                parentControlToChildren[parentControl] = childViews
+                switchHandlers[parentControl] = { [weak parentControl, group, childViews] in
+                    guard let c = parentControl else { return }
+                    let isOn = c.state == .on
+                    group.setter(isOn)
+                    for child in childViews {
+                        child.control.isEnabled = isOn
+                        child.label.textColor = isOn ? NSColor.labelColor : NSColor.secondaryLabelColor
+                    }
+                    NotificationCenter.default.post(name: .trayMenuSettingsChanged, object: nil)
+                }
+            }
+
+            // Thin separator between top-level sections
+            if idx < allSections.count - 1 {
+                let sep = NSBox()
+                sep.translatesAutoresizingMaskIntoConstraints = false
+                sep.boxType = .separator
+                stack.addArrangedSubview(sep)
+            }
+        }
+    }
+
+    // MARK: - Factories
+
+    private func makeRow(
+        title: String,
+        isOn: Bool,
+        bold: Bool = false,
+        indent: CGFloat = 0,
+        parentOn: Bool = true
+    ) -> (row: NSView, control: NSControl, label: NSTextField) {
+        let container = NSStackView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.orientation = .horizontal
+        container.spacing = 8
+        container.alignment = .centerY
+        container.edgeInsets = NSEdgeInsets(top: 3, left: 4 + indent, bottom: 3, right: 4)
+
+        let label = NSTextField(labelWithString: title)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = bold
+            ? NSFont.boldSystemFont(ofSize: NSFont.systemFontSize)
+            : NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        if !parentOn {
+            label.textColor = NSColor.secondaryLabelColor
+        }
+
+        let toggle = makeToggleControl(isOn: isOn, enabled: parentOn)
+
+        container.addArrangedSubview(label)
+        container.addArrangedSubview(toggle)
+
+        return (container, toggle, label)
+    }
+
+    private func makeToggleControl(isOn: Bool, enabled: Bool) -> NSControl {
+        if #available(macOS 10.15, *) {
+            let sw = NSSwitch()
+            sw.translatesAutoresizingMaskIntoConstraints = false
+            sw.target = self
+            sw.action = #selector(onToggle(_:))
+            sw.state = isOn ? .on : .off
+            sw.isEnabled = enabled
+            return sw
+        } else {
+            let btn = NSButton(checkboxWithTitle: "", target: self, action: #selector(onToggle(_:)))
+            btn.translatesAutoresizingMaskIntoConstraints = false
+            btn.state = isOn ? .on : .off
+            btn.isEnabled = enabled
+            return btn
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func onToggle(_ sender: NSControl) {
+        switchHandlers[sender]?()
+    }
+}
+

--- a/ClashFX/Views/TrayMenuSettingView.swift
+++ b/ClashFX/Views/TrayMenuSettingView.swift
@@ -34,7 +34,7 @@ class TrayMenuSettingView: NSView {
 
     // MARK: - State
 
-    private var switchHandlers: [NSControl: () -> Void] = [:]
+    private var switchHandlers: [NSControl: (Bool) -> Void] = [:]
     private var parentControlToChildren: [NSControl: [ChildView]] = [:]
     private var uiSetupDone = false
 
@@ -153,7 +153,7 @@ class TrayMenuSettingView: NSView {
         let stack = NSStackView()
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.orientation = .vertical
-        stack.alignment = .fill
+        stack.alignment = .leading
         stack.spacing = 0
         stack.edgeInsets = NSEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
 
@@ -173,9 +173,8 @@ class TrayMenuSettingView: NSView {
             switch entry {
             case .single(let row):
                 let (rowView, control, _) = makeRow(title: row.title, isOn: row.getter())
-                switchHandlers[control] = { [weak control, row] in
-                    guard let c = control else { return }
-                    row.setter(c.state == .on)
+                switchHandlers[control] = { [row] isOn in
+                    row.setter(isOn)
                     NotificationCenter.default.post(name: .trayMenuSettingsChanged, object: nil)
                 }
                 stack.addArrangedSubview(rowView)
@@ -194,9 +193,8 @@ class TrayMenuSettingView: NSView {
                         title: child.title, isOn: child.getter(),
                         indent: 16, parentOn: parentIsOn
                     )
-                    switchHandlers[childControl] = { [weak childControl, child] in
-                        guard let c = childControl else { return }
-                        child.setter(c.state == .on)
+                    switchHandlers[childControl] = { [child] isOn in
+                        child.setter(isOn)
                         NotificationCenter.default.post(name: .trayMenuSettingsChanged, object: nil)
                     }
                     childViews.append(ChildView(label: childLabel, control: childControl))
@@ -204,9 +202,7 @@ class TrayMenuSettingView: NSView {
                 }
 
                 parentControlToChildren[parentControl] = childViews
-                switchHandlers[parentControl] = { [weak parentControl, group, childViews] in
-                    guard let c = parentControl else { return }
-                    let isOn = c.state == .on
+                switchHandlers[parentControl] = { [group, childViews] isOn in
                     group.setter(isOn)
                     for child in childViews {
                         child.control.isEnabled = isOn
@@ -282,7 +278,16 @@ class TrayMenuSettingView: NSView {
     // MARK: - Actions
 
     @objc private func onToggle(_ sender: NSControl) {
-        switchHandlers[sender]?()
+        let isOn: Bool
+        if #available(macOS 10.15, *), let sw = sender as? NSSwitch {
+            isOn = sw.state == .on
+        } else if let btn = sender as? NSButton {
+            isOn = btn.state == .on
+        } else {
+            assertionFailure("Unexpected control type in onToggle: \(type(of: sender))")
+            isOn = false
+        }
+        switchHandlers[sender]?(isOn)
     }
 }
 

--- a/ClashFX/Views/TrayMenuSettingView.swift
+++ b/ClashFX/Views/TrayMenuSettingView.swift
@@ -99,6 +99,7 @@ class TrayMenuSettingView: NSView {
                 getter: { Settings.trayMenuShowConfigs },
                 setter: { Settings.trayMenuShowConfigs = $0 },
                 children: [
+                    ItemRow(title: NSLocalizedString("Config Switcher", comment: ""), getter: { Settings.trayMenuShowConfigSwitcher }, setter: { Settings.trayMenuShowConfigSwitcher = $0 }),
                     ItemRow(title: NSLocalizedString("Config Editor", comment: ""), getter: { Settings.trayMenuShowConfigEditor }, setter: { Settings.trayMenuShowConfigEditor = $0 }),
                     ItemRow(title: NSLocalizedString("Open Config Folder", comment: ""), getter: { Settings.trayMenuShowOpenConfigFolder }, setter: { Settings.trayMenuShowOpenConfigFolder = $0 }),
                     ItemRow(title: NSLocalizedString("Reload Config", comment: ""), getter: { Settings.trayMenuShowReloadConfig }, setter: { Settings.trayMenuShowReloadConfig = $0 }),


### PR DESCRIPTION
resolved #35

效果示意（macOS 10.15+）：

```
出站模式          ●——
节点切换          ————●

代理控制          ●——
  设置系统代理    ●——
  增强模式        ●——
  复制终端代理命令 ————●

通用设置          ●——
  ...
```

在 macOS 10.14 上会自动退化为复选框样式。

## Summary

Adds a **Tray Menu** configuration section to the **Appearance** tab in Settings, letting users choose which tray menu items are permanently visible.

## Design

The feature implements a two-level toggle hierarchy:

- **Level-1 (group) toggles**: A bold label with an `NSSwitch` that controls the parent item AND all its children at once. When turned off, child toggles are disabled and their labels dim.
- **Level-2 (individual) toggles**: Indented rows with `NSSwitch` controls that manage individual sub-items within a group. Only active when the parent is enabled.

Each row uses a **label-left / toggle-right** layout. `NSSwitch` is used on macOS 10.15+; a checkbox fallback is provided for macOS 10.14.

**Special cases handled per the spec:**
- **Node Switch** (节点切换): single toggle for all proxy group items — no sub-items.
- **Language** (语言): single toggle, no sub-items even though the menu has a submenu.
- **Configs** and **Help** menus: two-level (parent + individual sub-item toggles).

## Changes

| File | What changed |
|---|---|
| `Settings.swift` | 27 new `@UserDefault` boolean settings (default `true`) |
| `Notification.swift` | New `.trayMenuSettingsChanged` notification |
| `TrayMenuSettingView.swift` *(new)* | Scrollable toggle list — `NSSwitch` on macOS 10.15+, checkbox fallback on 10.14; label-left/switch-right layout; thin `NSBox` separators between sections; child labels dim when parent is off |
| `AppDelegate.swift` | 14 new `@IBOutlet`s; stores refs to dynamic `langMenuItem` / `configEditorMenuItem`; `applyTrayMenuVisibility()` called on launch + on settings change |
| `Main.storyboard` | 14 new outlet connections wired to AppDelegate |
| `MenuItemFactory.swift` | `updateProxyList` respects `trayMenuShowNodeSwitch` |
| `AppearanceSettingViewController.swift` | New "Tray Menu" NSBox section with fixed-height scroll view |
| `Localizable.strings` (en, zh-Hans, zh-Hant) | New localization keys for all section/item labels |

## Behavior

- All items are **visible by default** (settings default to `true`) — no regressions for existing users.
- Section separators in the tray menu are hidden automatically when all items in their section are hidden, avoiding orphaned separators.
- Dashboard/Connections items respect the existing macOS 10.15 availability check.