### PR TITLE
fix: restore Switch on parent group headers in TrayMenuSettingView, disable children when parent is off

### DIFF
--- a/ClashFX/Views/TrayMenuSettingView.swift
+++ b/ClashFX/Views/TrayMenuSettingView.swift
@@ -229,22 +229,46 @@ class TrayMenuSettingView: NSView {
             innerStack.bottomAnchor.constraint(equalTo: card.bottomAnchor),
         ])
 
-        let groupHeader = makeGroupHeaderRow(title: group.title)
+        let parentIsOn = group.getter()
+        let (groupHeader, parentControl, _) = makeRow(title: group.title, isOn: parentIsOn, bold: true)
         innerStack.addArrangedSubview(groupHeader)
         groupHeader.widthAnchor.constraint(equalTo: innerStack.widthAnchor).isActive = true
+
+        var childControls: [NSControl] = []
+        var childLabels: [NSTextField] = []
+        var childGetters: [() -> Bool] = []
 
         for child in group.children {
             let divider = makeInsetDivider()
             innerStack.addArrangedSubview(divider)
             divider.widthAnchor.constraint(equalTo: innerStack.widthAnchor).isActive = true
 
-            let (childRowView, childControl, _) = makeRow(title: child.title, isOn: child.getter(), indent: 12)
+            let (childRowView, childControl, childLabel) = makeRow(title: child.title, isOn: child.getter(), indent: 12, parentOn: parentIsOn)
+            childControls.append(childControl)
+            childLabels.append(childLabel)
+            childGetters.append(child.getter)
             switchHandlers[childControl] = { [child] isOn in
                 child.setter(isOn)
                 NotificationCenter.default.post(name: .trayMenuSettingsChanged, object: nil)
             }
             innerStack.addArrangedSubview(childRowView)
             childRowView.widthAnchor.constraint(equalTo: innerStack.widthAnchor).isActive = true
+        }
+
+        switchHandlers[parentControl] = { [group, childControls, childLabels, childGetters] isOn in
+            group.setter(isOn)
+            for (idx, control) in childControls.enumerated() {
+                control.isEnabled = isOn
+                childLabels[idx].textColor = isOn ? .labelColor : .tertiaryLabelColor
+                if isOn {
+                    if #available(macOS 10.15, *), let sw = control as? NSSwitch {
+                        sw.state = childGetters[idx]() ? .on : .off
+                    } else if let btn = control as? NSButton {
+                        btn.state = childGetters[idx]() ? .on : .off
+                    }
+                }
+            }
+            NotificationCenter.default.post(name: .trayMenuSettingsChanged, object: nil)
         }
 
         return card
@@ -290,26 +314,6 @@ class TrayMenuSettingView: NSView {
         ])
 
         return (container, toggle, label)
-    }
-
-    private func makeGroupHeaderRow(title: String) -> NSView {
-        let container = NSView()
-        container.translatesAutoresizingMaskIntoConstraints = false
-
-        let label = NSTextField(labelWithString: title)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = NSFont.systemFont(ofSize: NSFont.systemFontSize - 1, weight: .medium)
-        label.textColor = .secondaryLabelColor
-        label.lineBreakMode = .byTruncatingTail
-        container.addSubview(label)
-
-        NSLayoutConstraint.activate([
-            container.heightAnchor.constraint(greaterThanOrEqualToConstant: 28),
-            label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 12),
-            label.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-            label.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -12),
-        ])
-        return container
     }
 
     private func makeInsetDivider() -> NSView {


### PR DESCRIPTION
resolved #41

Parent group rows in `TrayMenuSettingView` (e.g. "Proxy Actions", "General Settings") lost their Switch control in a recent version. Users who had previously disabled a group can no longer re-enable it or control it at all.

## Changes

- **Replaced `makeGroupHeaderRow`** (label-only) with `makeRow(bold: true)` so parent group rows render a Switch like other rows
- **Child controls disabled when parent is off**: toggling a parent Switch to off disables all child Switches and dims their labels to `tertiaryLabelColor`
- **Child state restored on re-enable**: when the parent is toggled back on, each child Switch is restored to its persisted value via `child.getter()`
- **Removed** the now-dead `makeGroupHeaderRow` method

```swift
// Before: header row had no control
let groupHeader = makeGroupHeaderRow(title: group.title)

// After: header row includes a Switch; children are wired to it
let (groupHeader, parentControl, _) = makeRow(title: group.title, isOn: parentIsOn, bold: true)
// …
switchHandlers[parentControl] = { [group, childControls, childLabels, childGetters] isOn in
    group.setter(isOn)
    for (idx, control) in childControls.enumerated() {
        control.isEnabled = isOn
        childLabels[idx].textColor = isOn ? .labelColor : .tertiaryLabelColor
        if isOn { /* restore child state from getter */ }
    }
    NotificationCenter.default.post(name: .trayMenuSettingsChanged, object: nil)
}
```