### PR TITLE
release: update appcast.xml for v1.0.25

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -6,6 +6,24 @@
     <description>Most recent ClashFX updates</description>
     <language>en</language>
     <item>
+  <title>Version 1.0.25</title>
+  <description><![CDATA[
+    <h2>ClashFX v1.0.25</h2><ul><li><strong>Proxy Delay Diagnostics</strong> — Added detailed logs for proxy delay tests, including proxy name, benchmark URL, HTTP status, response body, and request error details.</li></ul>
+  ]]></description>
+  <pubDate>Thu, 30 Apr 2026 10:26:36 +0000</pubDate>
+  <sparkle:version>1.0.25</sparkle:version>
+  <sparkle:shortVersionString>1.0.25</sparkle:shortVersionString>
+  <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
+  <enclosure
+    url="https://github.com/Clash-FX/ClashFX/releases/download/1.0.25/ClashFX.dmg"
+    sparkle:version="1.0.25"
+    sparkle:shortVersionString="1.0.25"
+    sparkle:edSignature="SHXoGedietLOi6h7k+IAvcss6uUI0iAH2WIHhcIrtPJkJoToNNgAX+eXyvznsqEAh9R5BWCGvTRFCVCwJOoUDQ=="
+    length="89022112"
+    type="application/octet-stream"
+  />
+</item>
+    <item>
   <title>Version 1.0.24</title>
   <description><![CDATA[
     <h2>ClashFX v1.0.24</h2><ul><li><strong>Subscriptions</strong> — Fixed an issue where raw base64 share-link subscriptions failed to import due to improper validation order.</li><li><strong>Config Parser</strong> — Tightened remote config verification to catch semantic formatting errors earlier.</li></ul>


### PR DESCRIPTION
Auto-generated by CI. Updates Sparkle appcast for v1.0.25.