### PR TITLE
release: update appcast.xml for v1.0.27

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -6,6 +6,24 @@
     <description>Most recent ClashFX updates</description>
     <language>en</language>
     <item>
+  <title>Version 1.0.27</title>
+  <description><![CDATA[
+    <h2>ClashFX v1.0.27</h2><ul><li><strong>Subscription Status in Tray Menu</strong> — Each remote config now shows its remaining traffic and expiry next to its name in the Configs submenu. Data comes from the standard `Subscription-Userinfo` HTTP header, with fallback parsing of subscription metadata embedded in proxy entries.</li></ul>
+  ]]></description>
+  <pubDate>Fri, 01 May 2026 02:21:21 +0000</pubDate>
+  <sparkle:version>1.0.27</sparkle:version>
+  <sparkle:shortVersionString>1.0.27</sparkle:shortVersionString>
+  <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
+  <enclosure
+    url="https://github.com/Clash-FX/ClashFX/releases/download/1.0.27/ClashFX.dmg"
+    sparkle:version="1.0.27"
+    sparkle:shortVersionString="1.0.27"
+    sparkle:edSignature="JnVW8hoKXIh+j3A8+k77i2LKAY/VI+9XaqqNrm2TfimD8JBYupkh3BXHnsCkuwOgOplUqL0ywkavAHMjdfAFDw=="
+    length="88995095"
+    type="application/octet-stream"
+  />
+</item>
+    <item>
   <title>Version 1.0.26</title>
   <description><![CDATA[
     <h2>ClashFX v1.0.26</h2><ul><li><strong>Subscription Metadata Filtering</strong> — Removed subscription status entries such as remaining traffic, expiry, and filtered line notices from generated proxy groups so they are no longer tested as real nodes.</li><li><strong>Auto Speed Test Menu</strong> — Kept the Auto submenu open after ReTest by refreshing existing menu items instead of rebuilding the active menu.</li><li><strong>ClashFX Branding</strong> — Finished replacing leftover ClashX menu/error labels and stabilized startup menu binding.</li></ul>


### PR DESCRIPTION
Auto-generated by CI. Updates Sparkle appcast for v1.0.27.