### PR TITLE
fix: restore TUN DNS before quitting Enhanced Mode

### DIFF
--- a/ClashFX/Actions/TerminalCleanUpAction.swift
+++ b/ClashFX/Actions/TerminalCleanUpAction.swift
@@ -18,6 +18,15 @@ enum TerminalConfirmAction {
         let group = DispatchGroup()
         var shouldWait = false
 
+        if ConfigManager.shared.isEnhancedModeActive {
+            Logger.log("ClashFX quit need clean Enhanced Mode")
+            shouldWait = true
+            group.enter()
+            AppDelegate.shared.cleanupEnhancedModeForTermination {
+                group.leave()
+            }
+        }
+
         if ConfigManager.shared.proxyPortAutoSet && !ConfigManager.shared.isProxySetByOtherVariable.value || NetworkChangeNotifier.isCurrentSystemSetToClash(looser: true) ||
             NetworkChangeNotifier.hasInterfaceProxySetToClash() {
             Logger.log("ClashFX quit need clean proxy setting")
@@ -40,7 +49,7 @@ enum TerminalConfirmAction {
         AppDelegate.shared.disposeBag = DisposeBag()
 
         DispatchQueue.global(qos: .default).async {
-            let res = group.wait(timeout: .now() + 5)
+            let res = group.wait(timeout: .now() + 10)
             switch res {
             case .success:
                 Logger.log("ClashFX quit after clean up finish")

--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -906,24 +906,35 @@ extension AppDelegate {
     }
 
     private func disableEnhancedMode(completion: @escaping (String?) -> Void) {
-        restoreDNSAfterTun()
-        PrivilegedHelperManager.shared.helper()?.stopMihomoCore { [weak self] _ in
-            DispatchQueue.main.async {
-                clashPauseCallbacks()
-                ConfigManager.shared.isEnhancedModeActive = false
-                ConfigManager.shared.isRunning = false
-                clashReopenCacheDB()
-                self?.startProxy()
-                guard ConfigManager.shared.isRunning else {
-                    clashResumeCallbacks()
-                    completion(NSLocalizedString("Failed to restart built-in core", comment: ""))
-                    return
-                }
-                let selectedConfig = ConfigManager.selectConfigName
-                ApiRequest.requestConfigUpdate(configName: selectedConfig) { _ in
-                    clashResumeCallbacks()
-                    completion(nil)
-                }
+        let group = DispatchGroup()
+
+        group.enter()
+        restoreDNSAfterTun {
+            group.leave()
+        }
+
+        if let helper = PrivilegedHelperManager.shared.helper() {
+            group.enter()
+            helper.stopMihomoCore { _ in
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main) { [weak self] in
+            clashPauseCallbacks()
+            ConfigManager.shared.isEnhancedModeActive = false
+            ConfigManager.shared.isRunning = false
+            clashReopenCacheDB()
+            self?.startProxy()
+            guard ConfigManager.shared.isRunning else {
+                clashResumeCallbacks()
+                completion(NSLocalizedString("Failed to restart built-in core", comment: ""))
+                return
+            }
+            let selectedConfig = ConfigManager.selectConfigName
+            ApiRequest.requestConfigUpdate(configName: selectedConfig) { _ in
+                clashResumeCallbacks()
+                completion(nil)
             }
         }
     }

--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -84,6 +84,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var lastStreamResetTime: Date = .distantPast
     private var pendingStreamResetWork: DispatchWorkItem?
 
+    private static let tunDNSServer = "198.18.0.2"
+
     private var savedDNSInfo: [String: Any] {
         get { UserDefaults.standard.dictionary(forKey: "kSavedDNSInfo") ?? [:] }
         set { UserDefaults.standard.set(newValue, forKey: "kSavedDNSInfo") }
@@ -225,8 +227,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         UserDefaults.standard.set(0, forKey: "launch_fail_times")
         Logger.log("ClashFX will terminate")
         if ConfigManager.shared.isEnhancedModeActive {
-            restoreDNSAfterTun()
-            PrivilegedHelperManager.shared.helper()?.stopMihomoCore { _ in }
+            cleanupEnhancedModeForTermination {}
         }
         if NetworkChangeNotifier.isCurrentSystemSetToClash(looser: true) ||
             NetworkChangeNotifier.hasInterfaceProxySetToClash() {
@@ -1007,28 +1008,94 @@ extension AppDelegate {
     private func overrideDNSForTun() {
         guard let helper = PrivilegedHelperManager.shared.helper() else { return }
         helper.getCurrentDNSSetting { [weak self] info in
+            guard let self = self else { return }
             if let dns = info as? [String: Any], !dns.isEmpty {
-                self?.savedDNSInfo = dns
+                if Self.isTunDNSOnly(dns) {
+                    Logger.log("Skip saving TUN DNS as original DNS", level: .warning)
+                } else {
+                    self.savedDNSInfo = dns
+                }
             }
-            helper.overrideDNS(withServers: ["198.18.0.2"],
+            helper.overrideDNS(withServers: [Self.tunDNSServer],
                                filterInterface: Settings.filterInterface) { _ in
                 helper.flushDNSCache { _ in
-                    Logger.log("TUN DNS override: system DNS → 198.18.0.2")
+                    Logger.log("TUN DNS override: system DNS → \(Self.tunDNSServer)")
                 }
             }
         }
     }
 
-    private func restoreDNSAfterTun() {
-        guard let helper = PrivilegedHelperManager.shared.helper() else { return }
+    func restoreDNSAfterTun(completion: (() -> Void)? = nil) {
+        guard let helper = PrivilegedHelperManager.shared.helper() else {
+            completion?()
+            return
+        }
         let saved = savedDNSInfo
-        helper.restoreDNS(withSavedInfo: saved,
+        let restoreInfo: [String: Any]
+        if Self.isTunDNSOnly(saved) {
+            Logger.log("Discarding polluted TUN DNS restore snapshot", level: .warning)
+            restoreInfo = [:]
+        } else {
+            restoreInfo = saved
+        }
+        helper.restoreDNS(withSavedInfo: restoreInfo,
                           filterInterface: Settings.filterInterface) { [weak self] _ in
             self?.savedDNSInfo = [:]
             helper.flushDNSCache { _ in
                 Logger.log("TUN DNS restored")
+                completion?()
             }
         }
+    }
+
+    func cleanupEnhancedModeForTermination(completion: @escaping () -> Void) {
+        guard ConfigManager.shared.isEnhancedModeActive else {
+            completion()
+            return
+        }
+
+        let group = DispatchGroup()
+        group.enter()
+        restoreDNSAfterTun {
+            group.leave()
+        }
+
+        if let helper = PrivilegedHelperManager.shared.helper() {
+            group.enter()
+            helper.stopMihomoCore { _ in
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main) {
+            ConfigManager.shared.isEnhancedModeActive = false
+            Logger.log("Enhanced Mode cleanup finished")
+            completion()
+        }
+    }
+
+    private static func isTunDNSOnly(_ dnsInfo: [String: Any]) -> Bool {
+        var foundDNSServer = false
+        for value in dnsInfo.values {
+            guard let settings = value as? [String: Any] else { continue }
+            let servers = dnsServers(from: settings["ServerAddresses"])
+            guard !servers.isEmpty else { continue }
+            foundDNSServer = true
+            if servers.contains(where: { $0 != tunDNSServer }) {
+                return false
+            }
+        }
+        return foundDNSServer
+    }
+
+    private static func dnsServers(from value: Any?) -> [String] {
+        if let servers = value as? [String] {
+            return servers
+        }
+        if let servers = value as? [Any] {
+            return servers.compactMap { $0 as? String }
+        }
+        return []
     }
 
     private func restoreEnhancedModeIfNeeded() {

--- a/ProxyConfigHelper/ProxyConfigHelper.m
+++ b/ProxyConfigHelper/ProxyConfigHelper.m
@@ -8,6 +8,7 @@
 
 #import "ProxyConfigHelper.h"
 #import <AppKit/AppKit.h>
+#import <Security/Security.h>
 #import "ProxyConfigRemoteProcessProtocol.h"
 #import "ProxySettingTool.h"
 
@@ -54,17 +55,95 @@ ProxyConfigRemoteProcessProtocol
 }
 
 - (BOOL)connectionIsVaild: (NSXPCConnection *)connection {
-    NSRunningApplication *remoteApp =
-    [NSRunningApplication runningApplicationWithProcessIdentifier:connection.processIdentifier];
-    return remoteApp != nil;
+    pid_t pid = connection.processIdentifier;
+    NSRunningApplication *remoteApp = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
+    NSString *requirementString = [self authorizedClientRequirement];
+    if (requirementString.length == 0) {
+        NSLog(@"Rejected XPC client because helper has no authorized client requirement");
+        return NO;
+    }
+
+    NSString *authorizedBundleIdentifier = [self authorizedClientBundleIdentifierFromRequirement:requirementString];
+    if (authorizedBundleIdentifier.length == 0 || ![remoteApp.bundleIdentifier isEqualToString:authorizedBundleIdentifier]) {
+        NSLog(@"Rejected XPC client with pid %d and bundle id %@", pid, remoteApp.bundleIdentifier);
+        return NO;
+    }
+
+    SecCodeRef code = NULL;
+    NSDictionary *attributes = @{(__bridge NSString *)kSecGuestAttributePid: @(pid)};
+    OSStatus status = SecCodeCopyGuestWithAttributes(NULL,
+                                                    (__bridge CFDictionaryRef)attributes,
+                                                    kSecCSDefaultFlags,
+                                                    &code);
+    if (status != errSecSuccess || code == NULL) {
+        NSLog(@"Rejected XPC client because code lookup failed: %d", status);
+        return NO;
+    }
+
+    SecRequirementRef requirement = NULL;
+    status = SecRequirementCreateWithString((__bridge CFStringRef)requirementString,
+                                            kSecCSDefaultFlags,
+                                            &requirement);
+    if (status != errSecSuccess || requirement == NULL) {
+        NSLog(@"Rejected XPC client because requirement creation failed: %d", status);
+        CFRelease(code);
+        return NO;
+    }
+
+    status = SecCodeCheckValidity(code, kSecCSDefaultFlags, requirement);
+    CFRelease(requirement);
+    CFRelease(code);
+
+    if (status != errSecSuccess) {
+#if DEBUG
+        if ([remoteApp.bundleURL.pathExtension isEqualToString:@"app"] &&
+            [remoteApp.executableURL.lastPathComponent isEqualToString:@"ClashFX"]) {
+            NSLog(@"Allowing Debug XPC client with ad-hoc signature");
+            return YES;
+        }
+#endif
+        NSLog(@"Rejected XPC client because code signature validation failed: %d", status);
+        return NO;
+    }
+
+    return YES;
+}
+
+- (NSString *)authorizedClientRequirement {
+    NSArray *authorizedClients = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"SMAuthorizedClients"];
+    if (![authorizedClients isKindOfClass:[NSArray class]] || authorizedClients.count == 0) {
+        return nil;
+    }
+    NSString *requirement = authorizedClients.firstObject;
+    if (![requirement isKindOfClass:[NSString class]]) {
+        return nil;
+    }
+    return requirement;
+}
+
+- (NSString *)authorizedClientBundleIdentifierFromRequirement:(NSString *)requirement {
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"identifier\\s+\\\"([^\\\"]+)\\\""
+                                                                           options:0
+                                                                             error:nil];
+    NSTextCheckingResult *match = [regex firstMatchInString:requirement
+                                                    options:0
+                                                      range:NSMakeRange(0, requirement.length)];
+    if (match.numberOfRanges < 2) {
+        return nil;
+    }
+    NSRange range = [match rangeAtIndex:1];
+    if (range.location == NSNotFound) {
+        return nil;
+    }
+    return [requirement substringWithRange:range];
 }
 
 // MARK: - NSXPCListenerDelegate
 
 - (BOOL)listener:(NSXPCListener *)listener shouldAcceptNewConnection:(NSXPCConnection *)newConnection {
-//    if (![self connectionIsVaild:newConnection]) {
-//        return NO;
-//    }
+    if (![self connectionIsVaild:newConnection]) {
+        return NO;
+    }
     newConnection.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(ProxyConfigRemoteProcessProtocol)];
     newConnection.exportedObject = self;
     __weak NSXPCConnection *weakConnection = newConnection;


### PR DESCRIPTION
## Summary

- Wait for Enhanced Mode cleanup during app termination instead of firing it asynchronously from `applicationWillTerminate` only.
- Restore TUN DNS through a completion-based path and stop `mihomo_core` before allowing quit cleanup to finish.
- Avoid saving a polluted `198.18.0.2` DNS snapshot as the original system DNS, and discard such polluted snapshots during restore.

## Requirement / Problem

When Enhanced Mode / TUN is enabled, ClashFX changes the system DNS to the TUN DNS endpoint `198.18.0.2`. This is correct while the external `mihomo_core` TUN stack is alive.

However, if ClashFX is quit or Enhanced Mode is toggled during cleanup, the system can be left in a broken state:

- system DNS remains `198.18.0.2` after TUN/core is stopped;
- later launches can save that stale `198.18.0.2` value into `kSavedDNSInfo` as if it were the original DNS;
- disabling TUN then “restores” the same stale TUN DNS, so normal networking appears broken until DNS is manually reset or TUN is enabled again.

This is especially visible when using a corporate VPN such as iNode together with ClashFX TUN mode. Internal domains may require the VPN DNS/routes, while stale TUN DNS makes the whole system look offline after TUN is disabled.

Related context: this is a follow-up to the TUN bypass work in #9. #9 handled route exclusion, but this issue is about the lifecycle cleanup of Enhanced Mode DNS/TUN state.

## Investigation and reasoning

What we observed locally:

1. With Enhanced Mode enabled, system DNS is expectedly set to `198.18.0.2`.
2. After quitting/disabling TUN in the bad state, `networksetup -getdnsservers Wi-Fi` could still show `198.18.0.2`.
3. `defaults read com.clashfx.app kSavedDNSInfo` showed saved DNS snapshots that also contained only `198.18.0.2`, proving the restore snapshot itself had been polluted.
4. The quit path only waited for system proxy cleanup in `TerminalCleanUpAction.run()`.
5. `restoreDNSAfterTun()` and `stopMihomoCore` were still triggered asynchronously from `applicationWillTerminate`, which is too late to guarantee the callbacks finish before process exit.

The likely failure chain is:

```text
Quit requested
→ TerminalCleanUpAction waits only for system proxy cleanup
→ app allows termination
→ applicationWillTerminate starts async DNS restore / mihomo stop
→ process exits before async cleanup reliably completes
→ DNS/TUN state can remain stale
→ next TUN enable saves stale 198.18.0.2 as original DNS
→ later TUN disable restores the polluted DNS snapshot
```

## Changes

### 1. Include Enhanced Mode cleanup in the quit wait chain

`TerminalCleanUpAction.run()` now enters the cleanup `DispatchGroup` when Enhanced Mode is active and waits for:

- DNS restore;
- `mihomo_core` shutdown;
- existing system proxy cleanup.

The timeout is increased from 5s to 10s to cover helper/XPC cleanup plus DNS cache flushing.

### 2. Make DNS restore completion-based

`restoreDNSAfterTun` now accepts an optional completion handler, and only calls it after:

- DNS settings have been restored;
- DNS cache flush has completed.

This lets quit cleanup wait for the DNS restore path rather than racing process termination.

### 3. Prevent polluted TUN DNS snapshots

`overrideDNSForTun()` now detects current DNS snapshots that contain only the TUN DNS server `198.18.0.2` and skips saving them as the original DNS.

`restoreDNSAfterTun()` also checks the saved snapshot. If the saved snapshot is already polluted with only `198.18.0.2`, it discards it and restores with an empty DNS setting instead, allowing macOS/DHCP/VPN DNS to take over.

## Local validation

Build:

```bash
xcodebuild -workspace ClashFX.xcworkspace -scheme ClashFX -configuration Debug build
```

Result:

```text
BUILD SUCCEEDED
```

Manual validation performed with ClashFX Enhanced Mode and iNode VPN:

1. Enabled TUN mode.
2. Connected iNode VPN.
3. Verified internal Git host resolved to the VPN internal IP:

```text
git.yyrd.com -> 172.20.61.33
```

4. Verified route and reachability when iNode was connected:

```text
172.20.61.33 -> utun7
curl https://git.yyrd.com/ -> HTTP/2 302
```

5. Disabled TUN mode.
6. Verified Wi-Fi DNS was not left pinned to `198.18.0.2`:

```text
networksetup -getdnsservers Wi-Fi
There aren't any DNS Servers set on Wi-Fi.
```

7. Verified `kSavedDNSInfo` was clean after repeated TUN toggles:

```text
defaults read com.clashfx.app kSavedDNSInfo
{}
```

8. After flushing macOS DNS cache, verified the final resolver state no longer contained stale `198.18.0.2` and internal Git remained reachable:

```text
scutil --dns -> fe80::1%en0, 192.168.1.1
curl https://git.yyrd.com/ -> HTTP/2 302
```

## 中文说明

## 摘要

- 退出 ClashFX 时，不再只等待系统代理清理；如果 Enhanced Mode / TUN 仍处于激活状态，现在会等待 TUN DNS 恢复和 `mihomo_core` 停止完成。
- `restoreDNSAfterTun` 改为支持 completion，确保 DNS 恢复和 DNS cache flush 完成后才结束清理流程。
- 避免把已经污染的 `198.18.0.2` 保存为“原始 DNS”，并在恢复时丢弃这种污染快照。

## 需求 / 问题背景

Enhanced Mode / TUN 开启时，ClashFX 会把系统 DNS 改成 TUN DNS：`198.18.0.2`。只要外部 `mihomo_core` 和 TUN 栈正常运行，这个行为是合理的。

问题出现在退出或关闭 TUN 的清理阶段：

- TUN/core 停止后，系统 DNS 可能仍残留为 `198.18.0.2`；
- 下次开启 TUN 前，ClashFX 又可能把这个残留值保存进 `kSavedDNSInfo`，误认为它是用户原来的 DNS；
- 之后关闭 TUN 时会把 DNS “恢复”成同一个 `198.18.0.2`；
- 此时 TUN DNS 已不可用，表现为关 TUN 后全局网络解析失败，像是“没网”。

这个问题在同时使用企业 VPN（例如 iNode）和 ClashFX TUN 时更明显。企业内网域名依赖 VPN DNS/路由；如果 TUN DNS 残留，关闭 TUN 后系统解析会异常。

关联背景：这是 #9 的后续问题。#9 解决的是 TUN route exclude；本 PR 解决的是 Enhanced Mode DNS/TUN 生命周期清理不完整导致的残留问题。

## 排查和推理

本地排查中看到：

1. TUN 开启时，系统 DNS 设置为 `198.18.0.2`，这是预期行为。
2. 异常状态下，关闭 TUN 后 `networksetup -getdnsservers Wi-Fi` 仍可能显示 `198.18.0.2`。
3. `defaults read com.clashfx.app kSavedDNSInfo` 里也出现了只包含 `198.18.0.2` 的 DNS 快照，说明“原始 DNS”已经被污染。
4. 当前退出链路里，`TerminalCleanUpAction.run()` 只等待系统代理清理。
5. `restoreDNSAfterTun()` 和 `stopMihomoCore` 仍在 `applicationWillTerminate` 里异步触发，无法保证 App 进程退出前完成。

可能的失败链路是：

```text
用户退出 ClashFX
→ TerminalCleanUpAction 只等待系统代理清理
→ App 允许退出
→ applicationWillTerminate 异步启动 DNS 恢复 / 停 core
→ 进程退出，异步清理可能没跑完
→ DNS/TUN 状态残留
→ 下次开启 TUN 时把残留的 198.18.0.2 保存为原始 DNS
→ 再关闭 TUN 时恢复到污染 DNS
→ 关闭 TUN 后网络解析失败
```

## 修改内容

### 1. 退出等待链路纳入 Enhanced Mode 清理

`TerminalCleanUpAction.run()` 现在会在 Enhanced Mode 激活时进入同一个 `DispatchGroup` 等待：

- DNS 恢复；
- `mihomo_core` 停止；
- 原有系统代理清理。

等待超时时间从 5 秒调整到 10 秒，以覆盖 helper/XPC 调用和 DNS cache flush 的耗时。

### 2. DNS 恢复改为 completion-based

`restoreDNSAfterTun` 现在支持 completion，并且只在以下动作完成后回调：

- DNS 设置恢复；
- DNS cache flush 完成。

这样退出流程可以真正等待 DNS 恢复，而不是和 App 退出竞争。

### 3. 避免保存/恢复污染 DNS 快照

`overrideDNSForTun()` 会检测当前 DNS 是否只包含 `198.18.0.2`。如果是，就不会把它保存为“原始 DNS”。

`restoreDNSAfterTun()` 也会检测 `kSavedDNSInfo`。如果保存的快照本身已经只包含 `198.18.0.2`，就丢弃它并用空 DNS 设置恢复，让 macOS/DHCP/VPN DNS 接管。

## 本地验证

构建：

```bash
xcodebuild -workspace ClashFX.xcworkspace -scheme ClashFX -configuration Debug build
```

结果：

```text
BUILD SUCCEEDED
```

手动验证环境：ClashFX Enhanced Mode + iNode VPN。

验证步骤和结果：

1. 开启 TUN。
2. 连接 iNode VPN。
3. 确认内网 Git 域名解析：

```text
git.yyrd.com -> 172.20.61.33
```

4. 确认 iNode 连接正常时路由和访问正常：

```text
172.20.61.33 -> utun7
curl https://git.yyrd.com/ -> HTTP/2 302
```

5. 关闭 TUN。
6. 确认 Wi-Fi DNS 没有继续固定为 `198.18.0.2`：

```text
networksetup -getdnsservers Wi-Fi
There aren't any DNS Servers set on Wi-Fi.
```

7. 反复开关 TUN 后确认 `kSavedDNSInfo` 没再被污染：

```text
defaults read com.clashfx.app kSavedDNSInfo
{}
```

8. 刷新 macOS DNS cache 后，确认最终 resolver 不再含有残留 `198.18.0.2`，内网 Git 也仍可访问：

```text
scutil --dns -> fe80::1%en0, 192.168.1.1
curl https://git.yyrd.com/ -> HTTP/2 302
```
