### PR TITLE
fix(#66): use MaxMind MMDB instead of mihomo metadb for GEOIP update

### DIFF
--- a/ClashFX/General/Managers/Settings.swift
+++ b/ClashFX/General/Managers/Settings.swift
@@ -9,7 +9,8 @@
 import Foundation
 
 enum Settings {
-    static let defaultMmdbDownloadUrl = "https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geoip.metadb"
+    // Must be MaxMind MMDB format (verifyGEOIPDataBase uses oschwald/geoip2-golang, which rejects mihomo's proprietary .metadb).
+    static let defaultMmdbDownloadUrl = "https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/country.mmdb"
     @UserDefault("mmdbDownloadUrl", defaultValue: defaultMmdbDownloadUrl)
     static var mmdbDownloadUrl: String
 


### PR DESCRIPTION
## Summary

Fixes #66 — every GEOIP update via **More Settings → Debug → Update GEOIP Database** failed with "Database verify fail" since at least v1.0.29.

## Root cause

`Settings.defaultMmdbDownloadUrl` pointed to `meta-rules-dat/.../geoip.metadb`, which uses mihomo's proprietary `Meta-geoip0` format. `verifyGEOIPDataBase()` in `goClash/main.go` uses [`oschwald/geoip2-golang`](https://github.com/oschwald/geoip2-golang), which only supports standard MaxMind formats. Opening the metadb file fails with:

```
geoip2: reader does not support the "Meta-geoip0" database type
```

After verification fails, `checkMMDB()` deletes the freshly downloaded file, so the update appears to do nothing useful.

## Reproduction

```sh
curl -sL https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geoip.metadb -o /tmp/x.metadb
# database_type = "Meta-geoip0"  -> oschwald/geoip2-golang.Open() fails

curl -sL https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/country.mmdb -o /tmp/x.mmdb
# database_type = "GeoLite2-Country" -> opens fine
```

## Fix

Switch the default URL to `country.mmdb` from the same release (standard MaxMind `GeoLite2-Country` format).

## Note (out of scope for this PR)

The reporter also mentioned "clicking Update GEO in the dashboard does nothing". That is a separate issue:
- `ClashWebViewContoller.swift` actively hides the **GEO Databases** row in the dashboard via `hideUpgradeJS` (`HIDE_LABELS = ['GEO Databases', ...]`).
- If the user sees and clicks the row anyway (i18n / localized button text not matching the English label), mihomo internally does try to download `geoip.metadb` (its built-in default), succeeds, but ClashFX's bundled MMDB on disk remains the verifier-friendly `Country.mmdb`.

That's a UX/policy decision and not addressed here.