### PR TITLE
fix(#65): accept ad-hoc signed clients in helper XPC validation

### DIFF
--- a/ProxyConfigHelper/ProxyConfigHelper.m
+++ b/ProxyConfigHelper/ProxyConfigHelper.m
@@ -95,13 +95,17 @@ ProxyConfigRemoteProcessProtocol
     CFRelease(code);
 
     if (status != errSecSuccess) {
-#if DEBUG
+        // Ad-hoc signing fallback: SMAuthorizedClients requires a Developer ID
+        // certificate (subject.OU = MEWHFZ92DY), which ad-hoc signed builds
+        // cannot satisfy. Bundle ID was already validated above; accept the
+        // connection if the executable matches a ClashFX .app bundle.
+        // TODO(#65): remove once releases ship with a Developer ID signature.
         if ([remoteApp.bundleURL.pathExtension isEqualToString:@"app"] &&
             [remoteApp.executableURL.lastPathComponent isEqualToString:@"ClashFX"]) {
-            NSLog(@"Allowing Debug XPC client with ad-hoc signature");
+            NSLog(@"Allowing XPC client with ad-hoc signature (pid=%d, bundle=%@)",
+                  pid, remoteApp.bundleIdentifier);
             return YES;
         }
-#endif
         NSLog(@"Rejected XPC client because code signature validation failed: %d", status);
         return NO;
     }


### PR DESCRIPTION
## Summary

Fixes #65 — since v1.0.30 the privileged helper rejects every XPC connection from ad-hoc signed releases, breaking system proxy toggle and looping the helper install dialog.

## Root cause

PR #63 (commit `3a2b3e3e`) re-enabled `connectionIsValid:` in `listener:shouldAcceptNewConnection:` and replaced the old nil-check with `SecCodeCheckValidity` against `SMAuthorizedClients`:

```
identifier "com.clashfx.app" and ... certificate leaf[subject.OU] = MEWHFZ92DY
```

Release builds are ad-hoc signed (`TeamIdentifier=not set`), so `SecCodeCheckValidity` always fails. The pre-existing `#if DEBUG` escape hatch is unreachable in release builds, so every XPC call is rejected:

```
Helper connection was closed with error: Code=4097 ...
enableProxy fail: 0 0
```

## Fix

Lift the `.app`-bundle / `ClashFX` executable check out of the `#if DEBUG` block. When `SecCodeCheckValidity` fails, accept the connection if the executable matches a ClashFX `.app` bundle. Bundle ID was already validated above (`authorizedClientBundleIdentifierFromRequirement:` → `com.clashfx.app`), so this reduces to "valid bundle ID + matching executable name" — the same level of trust the helper had before PR #63 enabled the strict check, plus the explicit log for visibility.

The strict signature path still runs first and will become the only accepted path automatically once releases ship with a real Developer ID signature satisfying the `subject.OU = MEWHFZ92DY` requirement (no further code change needed at that point).

## Notes

- Bundle ID alone is not strong identity (an attacker can claim any `CFBundleIdentifier`), so this is intentionally a temporary measure tracked by the `TODO(#65)` comment.
- A proper long-term fix is to ship ClashFX with a Developer ID certificate; once that lands, this fallback can be deleted in one commit.

## Diff size

`+7 / -3` in `ProxyConfigHelper/ProxyConfigHelper.m`.