### PR TITLE
fix(#70): include with_gvisor build tag in goClash archive

### DIFF
--- a/ClashFX/goClash/build_clash_universal.py
+++ b/ClashFX/goClash/build_clash_universal.py
@@ -22,7 +22,7 @@ go_bin = "go"
 
 def build_clash(version, build_time, arch):
     command = f"""
-{go_bin} build -trimpath -ldflags '-X "github.com/metacubex/mihomo/constant.Version={version}" \
+{go_bin} build -trimpath -tags with_gvisor -ldflags '-X "github.com/metacubex/mihomo/constant.Version={version}" \
 -X "github.com/metacubex/mihomo/constant.BuildTime={build_time}"' \
 -buildmode=c-archive -o goClash_{arch}.a """
     envs = os.environ.copy()


### PR DESCRIPTION
## Summary

Fixes #70 — config loading fails for any profile containing a WireGuard proxy:

```
proxy 0: create WireGuard device: gVisor is not included in this build, rebuild with -tags with_gvisor
```

## Root Cause

The mihomo core ships in two flavors in this project:

| Artifact | Source | Used by | `with_gvisor` |
|---|---|---|---|
| `goClash.a` | `goClash/main.go` (`-buildmode=c-archive`) | **Main app process** via cgo — config parsing, proxy creation | ❌ missing |
| `mihomo_core` | `goClash/mihomo-bin/main.go` (standalone binary) | Auxiliary scenarios | ✅ present |

`build_clash_universal.py` already passed `-tags with_gvisor` for `mihomo_core` (line 51), but **not** for `goClash.a` (line 25). Since config loading and WireGuard device creation happen inside the main process via `goClash.a`, mihomo's tag-gated WireGuard implementation was unavailable and rejected every WireGuard proxy.

The `github.com/metacubex/gvisor` dependency is already present in `go.mod`, so this is purely a missing build flag — no new dependency, no Go code changes.

## Change

One-line addition of `-tags with_gvisor` to the `build_clash` archive command, matching what `build_mihomo_bin` already does.

## Local Verification

Rebuilt with the patch, then compared symbol tables:

| | Before | After |
|---|---|---|
| `goClash.a` size | 165 MB | 184 MB (+20 MB gVisor netstack) |
| `gvisor` symbols (`nm goClash.a \| grep -ic gvisor`) | 2 (forward decls only) | 7350 |

Build completes cleanly through both `arm64` and `amd64` arches and the universal `lipo` merge.

## Impact

- **WireGuard proxies now load** as expected.
- **Binary size** +~20 MB (gVisor userspace network stack).
- **Runtime cost** zero unless a WireGuard proxy is actually instantiated.
- **Enhanced Mode (TUN)** unaffected — uses `sing-tun`, not gVisor.
- **CGO / signing / notarize flow** unchanged.