### PR TITLE
release: update appcast.xml for v1.1.2.2

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -6,6 +6,25 @@
     <description>Most recent ClashFX updates</description>
     <language>en</language>
     <item>
+  <title>Version 1.1.2.2 (Lab)</title>
+  <description><![CDATA[
+    <h2>ClashFX v1.1.2.2 (Lab)</h2><ul><li><strong>Ignore List in Rule Mode Now Actually Bypasses</strong> — `More Settings → Ignore List` entries were previously ignored by mihomo in Rule mode, leaving the toggle a silent no-op for users not on Enhanced Mode. ClashFX now translates each entry into the appropriate `DOMAIN` / `DOMAIN-SUFFIX` / `IP-CIDR` / `IP-CIDR6` `DIRECT` rule and injects them ahead of your existing `rules:` into a runtime config consumed by mihomo, so bypass entries take effect immediately on reload. Your source config file is never modified. Enhanced Mode and iCloud configs are skipped intentionally and fall back to the original behavior. (#110, #104)</li><li><strong>WebSocket Crash on Traffic/Log Stream Fixed</strong> — Sparse `EXC_BAD_ACCESS` crashes inside `_outputStreamCallbackFunc` under the `com.vluxe.starscream.websocket` queue have been eliminated by upgrading Starscream from 3.1.1 to 4.0.8. The stream lifecycle was rewritten around the new event-based delegate, with manual connection tracking, `forceDisconnect()` retire semantics, assign-before-connect ordering, main-thread retry timers, and `.peerClosed` handling so the menu bar speed indicator and Connections panel recover cleanly across network changes, sleep/wake, and core restarts. (#109)</li><li><strong>Disable Enhanced Mode Re-applies Ignore List Rules</strong> — When you toggle Enhanced Mode off, the subsequent config reload now routes through the same rule-patching path as a manual reload, so any configured Ignore List entries are immediately reflected in Rule mode instead of waiting for the next manual reload.</li></ul>
+  ]]></description>
+  <pubDate>Thu, 28 May 2026 11:04:19 +0000</pubDate>
+  <sparkle:version>1001002002</sparkle:version>
+  <sparkle:shortVersionString>1.1.2.2</sparkle:shortVersionString>
+            <sparkle:channel>lab</sparkle:channel>
+          <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
+  <enclosure
+    url="https://github.com/Clash-FX/ClashFX/releases/download/1.1.2.2/ClashFX.dmg"
+    sparkle:version="1001002002"
+    sparkle:shortVersionString="1.1.2.2"
+    sparkle:edSignature="9s19bFyuZvPRW0I+K2ZhACLO5SkGXVMtzJU5ZW4Lr7gJHkBWBE2JgSWgJdsE4sX5HOOOJzo9h4zOnpFxgihwBA=="
+    length="94432436"
+    type="application/x-apple-diskimage"
+  />
+</item>
+    <item>
   <title>Version 1.1.2.1 (Lab)</title>
   <description><![CDATA[
     <h2>ClashFX v1.1.2.1 (Lab)</h2><ul><li><strong>Status Bar Menu No Longer Greys Out Unexpectedly</strong> — Action items in the status bar menu (Set as System Proxy, Enhanced Mode, Copy Terminal Command, Quit, etc.) could become disabled when another window briefly stole the responder chain (e.g. during Sparkle update prompts or Settings sheets). All menu items now have explicit targets and a centralized `validateMenuItem:` implementation, so the menu state remains correct regardless of focus changes.</li><li><strong>Bypass Common Chinese Apps Now Reflects Enhanced Mode</strong> — The "Bypass Common Chinese Apps" toggle relies on `PROCESS-NAME` rules that only resolve under Enhanced Mode (TUN). Under Rule mode mihomo cannot see the originating process, so the toggle was previously a silent no-op. It is now disabled in Rule mode with a tooltip explaining the requirement; toggling Enhanced Mode on automatically re-enables it.</li><li><strong>External Control Mode No Longer Breaks Other Menu Items</strong> — Selecting an External Control instance used to disable Sparkle's auto-validation for the entire status menu, which could leave unrelated items greyed out. Disable logic now targets only the actions that genuinely don't apply to a remote core (Set as System Proxy, Copy Terminal Command), while everything else stays usable.</li></ul>


### PR DESCRIPTION
Auto-generated by CI. Updates Sparkle appcast for v1.1.2.2.