### PR TITLE
release: update appcast.xml for v1.1.4.6

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -6,6 +6,25 @@
     <description>Most recent ClashFX updates</description>
     <language>en</language>
     <item>
+  <title>Version 1.1.4.6 (Lab)</title>
+  <description><![CDATA[
+    <h2>ClashFX v1.1.4.6 (Lab)</h2><ul><li><strong>Menu Bar Speed Text Looks More Balanced</strong> — The menu bar upload/download speed now uses the macOS monospaced-digit menu font, uppercase units, and a space between the number and unit, so labels like `186 B/S` and `1.2 KB/S` no longer look cramped or visually mismatched.</li><li><strong>Turn Off All Proxy Modes Is Localized</strong> — The tray-menu shortcut for disabling System Proxy and Enhanced Mode now has localized text and tooltip strings across English, Simplified Chinese, Traditional Chinese, Japanese, and Russian instead of falling back to English in non-English menus.</li></ul>
+  ]]></description>
+  <pubDate>Mon, 22 Jun 2026 08:24:46 +0000</pubDate>
+  <sparkle:version>1001004006</sparkle:version>
+  <sparkle:shortVersionString>1.1.4.6</sparkle:shortVersionString>
+            <sparkle:channel>lab</sparkle:channel>
+          <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
+  <enclosure
+    url="https://github.com/Clash-FX/ClashFX/releases/download/1.1.4.6/ClashFX.dmg"
+    sparkle:version="1001004006"
+    sparkle:shortVersionString="1.1.4.6"
+    sparkle:edSignature="zYZEMu5yU4dor0+VSfnun6wRXgZ02sKOiJjnjAtwt95cQHxBhJE4bSYcdTJjzr/ID8nF5zaZ6w0cJPQFJAjyAg=="
+    length="96315257"
+    type="application/x-apple-diskimage"
+  />
+</item>
+    <item>
   <title>Version 1.1.4.5 (Lab)</title>
   <description><![CDATA[
     <h2>ClashFX v1.1.4.5 (Lab)</h2><ul><li><strong>Enhanced Mode Disable Restores Manual Proxy Selection</strong> — Turning Enhanced Mode off now reapplies ClashFX's remembered proxy-group selections after the built-in core reloads, so selector groups no longer fall back to the config default such as Auto Select. (#134)</li></ul>


### PR DESCRIPTION
Auto-generated by CI. Updates Sparkle appcast for v1.1.4.6.