### PR TITLE
release: update appcast.xml for v1.1.5.2

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -6,6 +6,25 @@
     <description>Most recent ClashFX updates</description>
     <language>en</language>
     <item>
+  <title>Version 1.1.5.2 (Lab)</title>
+  <description><![CDATA[
+    <h2>ClashFX v1.1.5.2 (Lab)</h2><ul><li><strong>Proxy Recovers After Wake From Sleep</strong> — After macOS wakes from lid-close sleep, ClashFX now delays recovery until the network interface is ready, checks whether the mihomo API is still healthy, and restarts the active proxy mode when needed. This should avoid the state where proxy traffic stays broken until the app is manually restarted. (#142)</li><li><strong>Menu Bar Speed Font Restored</strong> — The menu bar upload/download speed text now uses the original ClashFX menu font again, preserving the latest macOS 26 custom drawing optimization while reverting the visual font regression.</li></ul>
+  ]]></description>
+  <pubDate>Thu, 02 Jul 2026 05:13:58 +0000</pubDate>
+  <sparkle:version>1001005002</sparkle:version>
+  <sparkle:shortVersionString>1.1.5.2</sparkle:shortVersionString>
+            <sparkle:channel>lab</sparkle:channel>
+          <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
+  <enclosure
+    url="https://github.com/Clash-FX/ClashFX/releases/download/1.1.5.2/ClashFX.dmg"
+    sparkle:version="1001005002"
+    sparkle:shortVersionString="1.1.5.2"
+    sparkle:edSignature="I53EXdFWxaJA4/g0XSEOhdTdhyUKpT7cIzn9fmEdBherZwkkci7idS1+D7sU68AKjmgeQN7tAznKXBFJ81W2DA=="
+    length="98318669"
+    type="application/x-apple-diskimage"
+  />
+</item>
+    <item>
   <title>Version 1.1.5.1 (Lab)</title>
   <description><![CDATA[
     <h2>ClashFX v1.1.5.1 (Lab)</h2><ul><li><strong>Custom Enhanced Mode Now Applies macOS DNS Override</strong> — When `Use Custom Config as-is` is enabled, ClashFX still keeps the selected config file untouched, but Enhanced Mode now runs the same TUN verification and temporary macOS DNS override as the generated-config path. This prevents system DNS from staying on the router DNS while the custom TUN core is running. (#139)</li></ul>


### PR DESCRIPTION
Auto-generated by CI. Updates Sparkle appcast for v1.1.5.2.