### PR TITLE
release: update appcast.xml for v1.1.7.1

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -6,6 +6,25 @@
     <description>Most recent ClashFX updates</description>
     <language>en</language>
     <item>
+  <title>Version 1.1.7.1 (Lab)</title>
+  <description><![CDATA[
+    <h2>ClashFX v1.1.7.1 (Lab)</h2><ul><li><strong>Config Selection Follows Local and iCloud Storage</strong> — Local and iCloud storage now remember their selected configurations independently. Switching storage restores the target location's previous selection, or chooses a non-default configuration when no selection has been saved yet. (#129)</li><li><strong>Delay Results Return After Restart</strong> — After a manual delay benchmark, ClashFX remembers the active configuration and test parameters, then silently repeats the benchmark once after the next matching startup. (#147)</li><li><strong>Proxy Speed Is Clearly Labeled</strong> — The menu-bar indicator now identifies itself as ClashFX proxy traffic and explains that it does not represent total system network speed. (#147)</li><li><strong>Optional Dock Icon Hiding</strong> — General settings now includes a disabled-by-default "Hide Dock Icon" switch. When enabled, ClashFX remains available from the menu bar without appearing in the Dock. (#147)</li></ul>
+  ]]></description>
+  <pubDate>Sat, 11 Jul 2026 04:00:08 +0000</pubDate>
+  <sparkle:version>1001007001</sparkle:version>
+  <sparkle:shortVersionString>1.1.7.1</sparkle:shortVersionString>
+            <sparkle:channel>lab</sparkle:channel>
+          <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
+  <enclosure
+    url="https://github.com/Clash-FX/ClashFX/releases/download/1.1.7.1/ClashFX.dmg"
+    sparkle:version="1001007001"
+    sparkle:shortVersionString="1.1.7.1"
+    sparkle:edSignature="7qOdZTl6gxhylN6JD9T5ha1BgonXaQEqw3VgAey7uZby69PmlDm7EFVfZDSIylfL/1Q1ghYIatR0ItEIpfZtBQ=="
+    length="96012380"
+    type="application/x-apple-diskimage"
+  />
+</item>
+    <item>
   <title>Version 1.1.7</title>
   <description><![CDATA[
     <h2>ClashFX v1.1.7</h2><ul><li><strong>iCloud Config Switching Refreshes Immediately</strong> — Switching the iCloud config-storage option now refreshes the configuration list and reloads a valid configuration from the newly selected storage location without requiring an app restart. (#129)</li><li><strong>Remote Config Renames Keep Working</strong> — When a subscription replaces its placeholder filename with the server-provided name, ClashFX now updates the active-config and remembered proxy references and removes the obsolete file. (#129)</li><li><strong>Settings Section Headers Are Clearer</strong> — Section headers now sit above their cards with consistent spacing, use a distinct secondary style, and no longer clip or run into the preceding section. General settings also adds meaningful headers for application, network automation, connectivity test, and bypass-rule sections. (#129)</li><li><strong>Copy Shortcuts No Longer Intercept Command-C</strong> — The two copy-command shortcuts now default to Control-Option-C and Control-Option-Shift-C. Existing Command-C and Option-Command-C bindings are migrated automatically once so normal system copy works again. (#129)</li><li><strong>Enhanced Mode Has a Real Global Shortcut</strong> — Enhanced Mode now uses a configurable global shortcut with the default Control-Option-E, avoiding the earlier Command-Shift-E conflict with Xcode. (#129)</li></ul>


### PR DESCRIPTION
Auto-generated by CI. Updates Sparkle appcast for v1.1.7.1.