### PR TITLE
release: update appcast.xml for v1.1.8.4

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -6,6 +6,25 @@
     <description>Most recent ClashFX updates</description>
     <language>en</language>
     <item>
+  <title>Version 1.1.8.4 (Lab)</title>
+  <description><![CDATA[
+    <h2>ClashFX v1.1.8.4 (Lab)</h2><ul><li><strong>Outbound Mode No Longer Changes Unexpectedly</strong> — Removed the default global `⌥D`, `⌥R`, and `⌥G` bindings that could switch ClashFX from other apps. Upgrades clear only bindings that still match those legacy defaults, while preserving other custom shortcuts. (#179)</li><li><strong>The Last Mode Choice Now Wins Reliably</strong> — Outbound-mode changes are serialized, persisted only after the core accepts them, and verified against the core's actual mode. Config reloads and stale state reads can no longer overwrite the user's latest choice, and logs now record each change source and result. (#179)</li></ul>
+  ]]></description>
+  <pubDate>Thu, 23 Jul 2026 05:18:42 +0000</pubDate>
+  <sparkle:version>1001008004</sparkle:version>
+  <sparkle:shortVersionString>1.1.8.4</sparkle:shortVersionString>
+            <sparkle:channel>lab</sparkle:channel>
+          <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
+  <enclosure
+    url="https://github.com/Clash-FX/ClashFX/releases/download/1.1.8.4/ClashFX.dmg"
+    sparkle:version="1001008004"
+    sparkle:shortVersionString="1.1.8.4"
+    sparkle:edSignature="e1cImOjIB0F5MPxwQIBk5g9S7KX8oxxGEfJFLpMXPNddbebiy6aPQI2x06yyq5/CoOXF6x8Hhjok/sfVHlguAg=="
+    length="95538995"
+    type="application/x-apple-diskimage"
+  />
+</item>
+    <item>
   <title>Version 1.1.8.3 (Lab)</title>
   <description><![CDATA[
     <h2>ClashFX v1.1.8.3 (Lab)</h2><ul><li><strong>Enhanced Mode Recovers From a Closed TUN Read Loop</strong> — The bundled core now treats macOS `ENOTSOCK` as a closed connection, while ClashFX detects the fatal TUN read error and rebuilds Enhanced Mode instead of leaving traffic disconnected. (#147)</li><li><strong>Core Error Floods No Longer Exhaust Resources</strong> — Repeated core messages are rate-limited in the app, and the privileged helper caps the core log at 4 MB so a broken read loop cannot drive unbounded CPU, memory, or disk usage. (#147)</li><li><strong>Helper Upgrades and Reconnects Are More Reliable</strong> — ClashFX now reuses and safely resets its XPC connection, waits for helper readiness before cleaning stale cores, and replaces an outdated running helper before restoring Enhanced Mode. (#147)</li></ul>


### PR DESCRIPTION
Auto-generated by CI. Updates Sparkle appcast for v1.1.8.4.