### PR TITLE
fix: re-evaluate automatic groups after manual benchmarks

### DIFF
--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -2769,7 +2769,9 @@ extension AppDelegate {
                 benchmarkURL: benchmarkURL,
                 timeout: timeout
             ) {
-                self.finishSpeedTest(showNotifications: showNotifications)
+                ApiRequest.retestURLTestGroups(in: resp, timeout: timeout) {
+                    self.finishSpeedTest(showNotifications: showNotifications)
+                }
             }
         }
     }

--- a/ClashFX/General/ApiRequest.swift
+++ b/ClashFX/General/ApiRequest.swift
@@ -413,6 +413,75 @@ class ApiRequest {
         )
     }
 
+    static func getProxyGroupDelay(groupName: ClashProxyName,
+                                   benchmarkURL: String = Settings.benchMarkUrl,
+                                   expectedStatus: String? = nil,
+                                   timeout: Int = 5000,
+                                   callback: @escaping (([ClashProxyName: Int]) -> Void)) {
+        Logger.log("[Proxy Delay] Testing group '\(groupName)' with its configured URL")
+        var parameters: Parameters = ["timeout": timeout, "url": benchmarkURL]
+        if let expectedStatus, !expectedStatus.isEmpty {
+            parameters["expected"] = expectedStatus
+        }
+        req("/group/\(groupName.encoded)/delay",
+            method: .get,
+            parameters: parameters)
+            .responseData { res in
+                let statusCode = res.response?.statusCode ?? -1
+                switch res.result {
+                case let .success(value) where (200 ..< 300).contains(statusCode):
+                    let delays = JSON(value).dictionaryValue.mapValues(\.intValue)
+                    Logger.log(
+                        "[Proxy Delay] Group '\(groupName)' re-evaluated "
+                            + "\(delays.count) candidates, status: \(statusCode)"
+                    )
+                    callback(delays)
+                case .success, .failure:
+                    let body = res.data.flatMap { String(data: $0, encoding: .utf8) } ?? "<empty body>"
+                    Logger.log(
+                        "[Proxy Delay] Group '\(groupName)' re-evaluation failed, "
+                            + "status: \(statusCode), error: "
+                            + "\(res.error?.localizedDescription ?? "unknown error"), body: \(body)",
+                        level: .warning
+                    )
+                    callback([:])
+                }
+            }
+    }
+
+    static func retestURLTestGroups(in response: ClashProxyResp,
+                                    limitedTo groupNames: Set<ClashProxyName>? = nil,
+                                    timeout: Int,
+                                    maxConcurrent: Int = 3,
+                                    completion: @escaping () -> Void) {
+        typealias DelayTask = LimitedAsyncTaskRunner.Task
+        let groups = response.proxyGroups.filter { group in
+            group.type == .urltest && (groupNames == nil || groupNames?.contains(group.name) == true)
+        }
+        guard !groups.isEmpty else {
+            completion()
+            return
+        }
+
+        let tasks: [DelayTask] = groups.map { group in
+            { done in
+                getProxyGroupDelay(
+                    groupName: group.name,
+                    benchmarkURL: group.testUrl ?? Settings.benchMarkUrl,
+                    expectedStatus: group.expectedStatus,
+                    timeout: timeout
+                ) { _ in
+                    done()
+                }
+            }
+        }
+        Logger.log(
+            "[Proxy Delay] Re-evaluating \(groups.count) URLTest groups, "
+                + "max concurrency \(max(1, maxConcurrent))"
+        )
+        LimitedAsyncTaskRunner(tasks: tasks, maxConcurrent: maxConcurrent).start(completion: completion)
+    }
+
     static func benchmarkLeafProxies(in response: ClashProxyResp,
                                      benchmarkURL: String,
                                      timeout: Int,
@@ -528,20 +597,6 @@ class ApiRequest {
                 Logger.log("HeathCheck for \(proxy) finished")
             } else {
                 Logger.log("HeathCheck for \(proxy) failed:\(res.response?.statusCode ?? -1)")
-            }
-            completeHandler?()
-        }
-    }
-
-    static func resetAutoProxyGroup(group: ClashProxyName, completeHandler: (() -> Void)? = nil) {
-        Logger.log("[Proxy ReTest] Resetting auto proxy group '\(group)'")
-        req("/proxies/\(group.encoded)", method: .delete).responseData { res in
-            let statusCode = res.response?.statusCode ?? -1
-            if statusCode == 204 {
-                Logger.log("[Proxy ReTest] Auto proxy group '\(group)' reset")
-            } else {
-                let body = res.data.flatMap { String(data: $0, encoding: .utf8) } ?? "<empty body>"
-                Logger.log("[Proxy ReTest] Failed resetting auto proxy group '\(group)', status: \(statusCode), body: \(body)", level: .warning)
             }
             completeHandler?()
         }

--- a/ClashFX/Models/ClashProxy.swift
+++ b/ClashFX/Models/ClashProxy.swift
@@ -109,6 +109,8 @@ class ClashProxy: Codable {
     let now: ClashProxyName?
     let alive: Bool?
     let hidden: Bool?
+    let testUrl: String?
+    let expectedStatus: String?
     weak var enclosingResp: ClashProxyResp?
     weak var enclosingProvider: ClashProvider?
 
@@ -140,7 +142,7 @@ class ClashProxy: Codable {
     lazy var isSpeedTestable: Bool = !speedtestAble.isEmpty
 
     private enum CodingKeys: String, CodingKey {
-        case type, all, history, now, name, alive, hidden
+        case type, all, history, now, name, alive, hidden, testUrl, expectedStatus
     }
 
     lazy var maxProxyNameLength: CGFloat = {

--- a/ClashFX/Views/ProxyGroupSpeedTestMenuItem.swift
+++ b/ClashFX/Views/ProxyGroupSpeedTestMenuItem.swift
@@ -57,8 +57,17 @@ class ProxyGroupSpeedTestMenuItem: NSMenuItem {
         isEnabled = false
         updateViewTitle(NSLocalizedString("Testing", comment: ""))
 
-        ApiRequest.resetAutoProxyGroup(group: proxyGroup.name) {
-            self.scheduleMenuRefresh()
+        ApiRequest.getProxyGroupDelay(
+            groupName: proxyGroup.name,
+            benchmarkURL: proxyGroup.testUrl ?? Settings.benchMarkUrl,
+            expectedStatus: proxyGroup.expectedStatus
+        ) { _ in
+            DispatchQueue.main.async {
+                self.isTesting = false
+                self.isEnabled = true
+                self.updateViewTitle(self.testType.title)
+                self.scheduleMenuRefresh()
+            }
         }
     }
 
@@ -168,12 +177,23 @@ private class ProxyGroupSpeedTestMenuItemView: MenuItemBaseView {
         testGroup.notify(queue: .main) {
             [weak self] in
             guard let self = self, let menu = self.enclosingMenuItem else { return }
-            self.label.stringValue = menu.title
-            menu.isEnabled = true
-            self.setNeedsDisplay()
-            if !providers.isEmpty {
+            let finish = {
+                self.label.stringValue = menu.title
+                menu.isEnabled = true
+                self.setNeedsDisplay()
                 MenuItemFactory.refreshExistingMenuItems()
             }
+
+            guard let response = group.enclosingResp else {
+                finish()
+                return
+            }
+            ApiRequest.retestURLTestGroups(
+                in: response,
+                limitedTo: Set(group.all ?? []),
+                timeout: 5000,
+                completion: finish
+            )
         }
     }
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,27 @@
 ### Bug Fixes
 
+- **Automatic Groups Re-evaluate After Manual Delay Tests** — Completing a manual delay benchmark now triggers each affected `url-test` group to test its candidates again with the group's own URL and expected status. Stale selections are refreshed while Mihomo's configured `tolerance` continues to prevent unnecessary switching from small latency changes. (#147)
+
+### Contributors
+
+- @a51095 — Reported that Automatic Selection could keep an older candidate after a manual delay test found faster nodes. (#147)
+
+---
+
+### 修复
+
+- **手动延迟测速后会重新评估自动策略组** — 手动测速完成后，相关 `url-test` 策略组会使用各自配置的测速地址和预期状态重新测试候选节点；旧选择会及时刷新，同时继续保留 Mihomo 的 `tolerance` 容差，避免因细微延迟波动频繁切换。 (#147)
+
+### 贡献者
+
+- @a51095 — 反馈手动延迟测速发现更快节点后，自动选择仍可能保留旧候选节点的问题。 (#147)
+
+<!-- Previous release notes -->
+
+---
+
+### Bug Fixes
+
 - **System Proxy Bypass Changes Apply Immediately** — Editing the bypass list now reapplies the active macOS System Proxy settings and reloads the standard-mode runtime rules without requiring a proxy toggle or app restart. The settings copy also clarifies that Enhanced Mode bypasses belong in Profile Mixin. (#182)
 - **TUN Interface Error Storms Recover Automatically** — Repeated interface auto-detection failures are grouped and rate-limited before file logging, and a sustained error storm now triggers an Enhanced Mode rebuild instead of consuming CPU and growing logs indefinitely. (#183)
 - **Dashboard Version Indicators No Longer Suggest Unsupported Updates** — ClashFX now removes the upstream update dots, disables the bundled Dashboard's version actions, and explains that Dashboard and core updates are managed by ClashFX releases. (#184)

--- a/scripts/promote-to-stable.sh
+++ b/scripts/promote-to-stable.sh
@@ -68,7 +68,7 @@ if ! git diff --quiet HEAD; then
   echo "❌ Uncommitted changes. Stash or commit first." >&2
   exit 1
 fi
-git fetch -q origin main
+git fetch -q origin main --tags
 LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse origin/main)
 if [[ "$LOCAL" != "$REMOTE" ]]; then
@@ -87,6 +87,15 @@ IS_PRE=$(echo "$LAB_INFO" | python3 -c "import json,sys; print(json.load(sys.std
 PUB_AT=$(echo "$LAB_INFO" | python3 -c "import json,sys; print(json.load(sys.stdin)['publishedAt'])")
 if [[ "$IS_PRE" != "True" ]]; then
   echo "❌ Release $LAB_TAG is not prerelease. Refusing to promote a non-Lab build." >&2
+  exit 1
+fi
+LAB_COMMIT=$(git rev-list -n 1 "$LAB_TAG")
+if [[ -z "$LAB_COMMIT" ]]; then
+  echo "❌ Could not resolve Lab tag $LAB_TAG to a commit." >&2
+  exit 1
+fi
+if ! git merge-base --is-ancestor "$LAB_COMMIT" origin/main; then
+  echo "❌ Lab commit $LAB_COMMIT is not contained in origin/main." >&2
   exit 1
 fi
 LAB_AGE_HOURS=$(python3 -c "
@@ -133,7 +142,7 @@ fi
 echo
 
 echo "▶ Step 6/11 — Final confirm"
-echo "    Tag $STABLE_TAG → ${LOCAL:0:8} (current main HEAD)"
+echo "    Tag $STABLE_TAG → ${LAB_COMMIT:0:8} (Lab $LAB_TAG commit)"
 echo "    CI will: build, sign, release (prerelease=false), update appcast,"
 echo "             dispatch website (config.ts bump + Cloudflare deploy)"
 if [[ "$AUTO_YES" != true ]]; then
@@ -143,7 +152,7 @@ fi
 echo
 
 echo "▶ Step 7/11 — Create + push tag $STABLE_TAG"
-git tag "$STABLE_TAG" "$LOCAL"
+git tag "$STABLE_TAG" "$LAB_COMMIT"
 git push origin "$STABLE_TAG"
 echo "  ✓ Tag pushed"
 echo


### PR DESCRIPTION
## What changed

- Re-test affected `url-test` groups after global or per-group manual delay benchmarks.
- Use each automatic group’s own test URL and expected status.
- Make the automatic-group “ReTest” action perform a real group delay test and restore its menu state.
- Keep Mihomo’s existing `tolerance` behavior.
- Make Stable promotion tag the selected Lab commit rather than a later `[skip ci]` appcast commit.
- Add bilingual Lab release notes.

## Root cause

Manual benchmarks only updated leaf proxy histories. They did not invoke Mihomo’s group delay endpoint, so a `url-test` group could retain a previously fixed/cached candidate even after new leaf delays were available.

## Validation

- `git diff --check`
- `bash -n scripts/promote-to-stable.sh`
- Full unsigned Release build with Xcode 26.6: succeeded
- Isolated Mihomo smoke test: forced an automatic group to a dead candidate, invoked `/group/{name}/delay`, and verified selection recovered to the usable candidate

Closes the automatic-selection follow-up in #147.