### PR TITLE
fix: make enhanced mode startup errors actionable

### DIFF
--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -1682,7 +1682,7 @@ extension AppDelegate {
                 Settings.enhancedMode = !newState
                 self.enhancedModeMenuItem.state = !newState ? .on : .off
                 Logger.log("Enhanced Mode toggle failed: \(error)", level: .error)
-                NSUserNotificationCenter.default.postConfigErrorNotice(msg: error)
+                self.presentEnhancedModeToggleError(error, attemptedEnable: newState)
             } else {
                 Settings.enhancedMode = newState
                 self.enhancedModeMenuItem.state = newState ? .on : .off
@@ -1699,6 +1699,52 @@ extension AppDelegate {
             enableEnhancedMode(completion: completion)
         } else {
             disableEnhancedMode(completion: completion)
+        }
+    }
+
+    private func presentEnhancedModeToggleError(_ error: String, attemptedEnable: Bool) {
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.icon = NSApp.applicationIconImage
+        alert.messageText = NSLocalizedString(
+            attemptedEnable ? "Failed to Start Enhanced Mode" : "Failed to Stop Enhanced Mode",
+            comment: ""
+        )
+
+        let errorPrefix = "error:"
+        let normalizedError = (error.hasPrefix(errorPrefix)
+            ? String(error.dropFirst(errorPrefix.count))
+            : error)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let invalidExcludePrefix = "invalid TUN route exclude entries:"
+        let invalidExcludeEntries: String?
+        if normalizedError.hasPrefix(invalidExcludePrefix) {
+            invalidExcludeEntries = String(normalizedError.dropFirst(invalidExcludePrefix.count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            invalidExcludeEntries = nil
+        }
+
+        let shouldOfferSettings = invalidExcludeEntries?.isEmpty == false
+        if let invalidExcludeEntries, shouldOfferSettings {
+            alert.informativeText = String(
+                format: NSLocalizedString(
+                    "TUN Route Exclude contains invalid entries:\n%@\n\nSeparate entries with commas or new lines, or reset the list.",
+                    comment: ""
+                ),
+                invalidExcludeEntries
+            )
+            alert.addButton(withTitle: NSLocalizedString("Open Settings", comment: ""))
+            alert.addButton(withTitle: NSLocalizedString("OK", comment: ""))
+        } else {
+            alert.informativeText = normalizedError
+            alert.addButton(withTitle: NSLocalizedString("OK", comment: ""))
+        }
+
+        NSApp.activate(ignoringOtherApps: true)
+        let response = alert.runModal()
+        if shouldOfferSettings, response == .alertFirstButtonReturn {
+            actionMoreSetting(alert)
         }
     }
 

--- a/ClashFX/Support Files/en.lproj/Localizable.strings
+++ b/ClashFX/Support Files/en.lproj/Localizable.strings
@@ -596,3 +596,7 @@
 "Unsafe Command-key shortcuts were removed to restore standard macOS shortcuts. You can assign custom combinations in Settings > Global Shortcut." = "Unsafe Command-key shortcuts were removed to restore standard macOS shortcuts. You can assign custom combinations in Settings > Global Shortcut.";
 "Default proxy-mode shortcuts were removed to prevent accidental background mode changes. You can assign custom combinations in Settings > Global Shortcut." = "Default proxy-mode shortcuts were removed to prevent accidental background mode changes. You can assign custom combinations in Settings > Global Shortcut.";
 "Could not switch to %@. ClashFX kept the core's current proxy mode." = "Could not switch to %@. ClashFX kept the core's current proxy mode.";
+"Failed to Start Enhanced Mode" = "Failed to Start Enhanced Mode";
+"Failed to Stop Enhanced Mode" = "Failed to Stop Enhanced Mode";
+"TUN Route Exclude contains invalid entries:\n%@\n\nSeparate entries with commas or new lines, or reset the list." = "TUN Route Exclude contains invalid entries:\n%@\n\nSeparate entries with commas or new lines, or reset the list.";
+"Open Settings" = "Open Settings";

--- a/ClashFX/Support Files/ja.lproj/Localizable.strings
+++ b/ClashFX/Support Files/ja.lproj/Localizable.strings
@@ -589,3 +589,7 @@
 "Unsafe Command-key shortcuts were removed to restore standard macOS shortcuts. You can assign custom combinations in Settings > Global Shortcut." = "macOS の標準ショートカットを復元するため、安全でない Command キーのグローバルショートカットを削除しました。設定 > グローバルショートカットで任意の組み合わせを設定できます。";
 "Default proxy-mode shortcuts were removed to prevent accidental background mode changes. You can assign custom combinations in Settings > Global Shortcut." = "バックグラウンドでの意図しないモード変更を防ぐため、プロキシモードの既定ショートカットを削除しました。設定 > グローバルショートカットで任意の組み合わせを設定できます。";
 "Could not switch to %@. ClashFX kept the core's current proxy mode." = "%@ に切り替えられませんでした。ClashFX はコアの現在のプロキシモードを維持しました。";
+"Failed to Start Enhanced Mode" = "拡張モードを開始できませんでした";
+"Failed to Stop Enhanced Mode" = "拡張モードを停止できませんでした";
+"TUN Route Exclude contains invalid entries:\n%@\n\nSeparate entries with commas or new lines, or reset the list." = "TUN ルート除外に無効な項目があります：\n%@\n\n項目をカンマまたは改行で区切るか、リストをリセットしてください。";
+"Open Settings" = "設定を開く";

--- a/ClashFX/Support Files/ru.lproj/Localizable.strings
+++ b/ClashFX/Support Files/ru.lproj/Localizable.strings
@@ -589,3 +589,7 @@
 "Unsafe Command-key shortcuts were removed to restore standard macOS shortcuts. You can assign custom combinations in Settings > Global Shortcut." = "Небезопасные глобальные сочетания с Command удалены, чтобы восстановить стандартные сочетания macOS. Свои сочетания можно назначить в разделе «Настройки > Глобальные сочетания».";
 "Default proxy-mode shortcuts were removed to prevent accidental background mode changes. You can assign custom combinations in Settings > Global Shortcut." = "Сочетания клавиш режима прокси по умолчанию удалены, чтобы предотвратить случайное переключение в фоне. Назначить свои сочетания можно в разделе «Настройки > Глобальные сочетания».";
 "Could not switch to %@. ClashFX kept the core's current proxy mode." = "Не удалось переключиться на %@. ClashFX сохранил текущий режим прокси ядра.";
+"Failed to Start Enhanced Mode" = "Не удалось запустить расширенный режим";
+"Failed to Stop Enhanced Mode" = "Не удалось остановить расширенный режим";
+"TUN Route Exclude contains invalid entries:\n%@\n\nSeparate entries with commas or new lines, or reset the list." = "Список исключений маршрутов TUN содержит недопустимые элементы:\n%@\n\nРазделите элементы запятыми или переносами строк либо сбросьте список.";
+"Open Settings" = "Открыть настройки";

--- a/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
@@ -629,3 +629,7 @@
 "Unsafe Command-key shortcuts were removed to restore standard macOS shortcuts. You can assign custom combinations in Settings > Global Shortcut." = "已移除会拦截 macOS 常用命令的全局快捷键。可在“设置 > 全局快捷键”中重新指定自定义组合。";
 "Default proxy-mode shortcuts were removed to prevent accidental background mode changes. You can assign custom combinations in Settings > Global Shortcut." = "已移除默认的出站模式快捷键，避免在后台误切换模式。可在“设置 > 全局快捷键”中重新指定自定义组合。";
 "Could not switch to %@. ClashFX kept the core's current proxy mode." = "无法切换到 %@。ClashFX 已保留核心当前的代理模式。";
+"Failed to Start Enhanced Mode" = "增强模式启动失败";
+"Failed to Stop Enhanced Mode" = "增强模式停止失败";
+"TUN Route Exclude contains invalid entries:\n%@\n\nSeparate entries with commas or new lines, or reset the list." = "TUN 路由排除中包含无效条目：\n%@\n\n请使用逗号或换行分隔条目，或者重置该列表。";
+"Open Settings" = "打开设置";

--- a/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
@@ -589,3 +589,7 @@
 "Unsafe Command-key shortcuts were removed to restore standard macOS shortcuts. You can assign custom combinations in Settings > Global Shortcut." = "已移除會攔截 macOS 常用指令的全域快速鍵。可在「設定 > 全域快速鍵」中重新指定自訂組合。";
 "Default proxy-mode shortcuts were removed to prevent accidental background mode changes. You can assign custom combinations in Settings > Global Shortcut." = "已移除預設的出站模式快速鍵，避免在背景誤切換模式。可在「設定 > 全域快速鍵」中重新指定自訂組合。";
 "Could not switch to %@. ClashFX kept the core's current proxy mode." = "無法切換到 %@。ClashFX 已保留核心目前的代理模式。";
+"Failed to Start Enhanced Mode" = "增強模式啟動失敗";
+"Failed to Stop Enhanced Mode" = "增強模式停止失敗";
+"TUN Route Exclude contains invalid entries:\n%@\n\nSeparate entries with commas or new lines, or reset the list." = "TUN 路由排除中包含無效項目：\n%@\n\n請使用逗號或換行分隔項目，或者重設此列表。";
+"Open Settings" = "開啟設定";

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,27 @@
 ### Bug Fixes
 
+- **Enhanced Mode Startup Errors Are Now Actionable** — Failed Enhanced Mode toggles now show a prominent error dialog even when reduced notifications are enabled. Invalid TUN route-exclude entries are identified directly, with guidance to separate entries correctly and a shortcut to open Settings. (#190)
+
+### Contributors
+
+- @ljssafe — Reported that Enhanced Mode appeared to do nothing when an invalid TUN route-exclude entry prevented startup. (#190)
+
+---
+
+### 修复
+
+- **增强模式启动错误现在会明确提示并引导修正** — 增强模式切换失败时会直接显示醒目的错误弹窗，即使启用了“减少通知”也不会被隐藏。若 TUN 路由排除项格式无效，弹窗会指出具体条目、说明正确的分隔方式，并提供打开设置的快捷入口。 (#190)
+
+### 贡献者
+
+- @ljssafe — 反馈无效的 TUN 路由排除项导致增强模式无法启动，但界面看起来没有任何反应的问题。 (#190)
+
+<!-- Previous release notes -->
+
+---
+
+### Bug Fixes
+
 - **Automatic Groups Re-evaluate After Manual Delay Tests** — Completing a manual delay benchmark now triggers each affected `url-test` group to test its candidates again with the group's own URL and expected status. Stale selections are refreshed while Mihomo's configured `tolerance` continues to prevent unnecessary switching from small latency changes. (#147)
 
 ### Contributors


### PR DESCRIPTION
## What changed

- Show Enhanced Mode start/stop failures in a prominent modal dialog instead of a notification that can be suppressed.
- Detect invalid TUN route-exclude entries and show the exact invalid value with correction guidance.
- Add an “Open Settings” action for route-exclude errors.
- Localize the new UI in English, Simplified Chinese, Traditional Chinese, Japanese, and Russian.
- Add bilingual Lab release notes for `1.1.9.2`.

## Root cause

A failed Enhanced Mode toggle used the standard configuration-error notification path. When “Reduce Notifications” was enabled, that path intentionally suppressed the notification, so the menu state rolled back correctly but the click appeared to do nothing.

## Validation

- `git diff --check`
- `plutil -lint` for all five updated localization files
- SwiftFormat on `AppDelegate.swift`
- Full unsigned Release build with Xcode 26.6: succeeded

Closes the UX follow-up in #190.