### PR TITLE
fix: stabilize helper recovery and proxy benchmarks

### DIFF
--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -123,6 +123,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var disposeBag = DisposeBag()
     var statusItemView: StatusItemViewProtocol!
     var isSpeedTesting = false
+    private var activeBenchmarkSession: ApiRequest.BenchmarkSession?
 
     var runAfterConfigReload: (() -> Void)?
     var isConfigUpdating = false
@@ -136,6 +137,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var enhancedModeHealthTimer: Timer?
     private var isEnhancedModeHealthCheckInFlight = false
     private var consecutiveEnhancedModeHealthFailures = 0
+    private var enhancedModeHealthGraceUntil = Date.distantPast
     private var lastCoreLogRecoveryTime = Date.distantPast
     private var didCompleteStaleEnhancedCoreCleanup = false
     private var outboundModeRequestSequence = 0
@@ -154,7 +156,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private static let wakeRecoveryMaxAttempts = 3
     private static let wakeEnhancedModeRestartMaxAttempts = 3
     private static let enhancedModeHealthInterval: TimeInterval = 15
-    private static let enhancedModeHealthFailureThreshold = 2
+    private static let enhancedModeHealthFailureThreshold = 3
+    private static let enhancedModeHealthGracePeriod: TimeInterval = 60
+    private static let enhancedModeHealthRequestTimeout: TimeInterval = 5
+    private static let tunDNSRestoreTimeout: TimeInterval = 8
+    private static let staleEnhancedCoreCleanupTimeout: TimeInterval = 3
     private static let fatalTunRecoveryCooldown: TimeInterval = 30
     private static let runtimePatchedConfigPath = kConfigFolderPath + ".runtime_config.yaml"
 
@@ -211,6 +217,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func postFinishLaunching() {
         Logger.log("postFinishLaunching")
+        Settings.migrateLegacyBenchmarkURLIfNeeded()
         defer {
             DispatchQueue.main.asyncAfter(deadline: .now() + 8) {
                 self.checkMenuIconVisable()
@@ -272,8 +279,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             Logger.log("do not setup built in logger/traffic, useDirectApi = false")
         }
-        scheduleStaleMihomoCoreCleanupOnLaunch()
-
         // start proxy
         Logger.log("initClashCore")
         initClashCore()
@@ -1297,6 +1302,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             consecutiveEnhancedModeHealthFailures = 0
             return
         }
+        guard Date() >= enhancedModeHealthGraceUntil else {
+            consecutiveEnhancedModeHealthFailures = 0
+            return
+        }
         guard !isEnhancedModeHealthCheckInFlight else { return }
 
         isEnhancedModeHealthCheckInFlight = true
@@ -1474,7 +1483,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             complete(.unhealthy("invalid core API URL"))
             return
         }
-        var request = URLRequest(url: url, timeoutInterval: 2)
+        var request = URLRequest(
+            url: url,
+            timeoutInterval: Self.enhancedModeHealthRequestTimeout
+        )
         for header in ApiRequest.authHeader() {
             request.setValue(header.value, forHTTPHeaderField: header.name)
         }
@@ -1533,6 +1545,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if attemptsLeft == Self.wakeEnhancedModeRestartMaxAttempts {
             guard !isWakeEnhancedModeRestarting else { return }
             isWakeEnhancedModeRestarting = true
+            cancelActiveSpeedTestForCoreRecovery()
         }
 
         let wasActive = ConfigManager.shared.isEnhancedModeActive
@@ -1581,46 +1594,57 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         enhancedModeMenuItem.isEnabled = false
-        helper.stopMihomoCore { [weak self] stopError in
-            DispatchQueue.main.async {
-                guard let self = self else { return }
-                guard !attemptCompleted else { return }
-                if let stopError {
-                    Logger.log(
-                        "Wake recovery: failed to stop stale Enhanced Mode core: \(stopError)",
-                        level: .warning
-                    )
-                }
-
-                ConfigManager.shared.isEnhancedModeActive = false
-                self.refreshStatusItemViewStatus()
-
-                let completion: (String?) -> Void = { [weak self] error in
+        let stopAndRestart = { [weak self] in
+            helper.stopMihomoCore { [weak self] stopError in
+                DispatchQueue.main.async {
                     guard let self = self else { return }
                     guard !attemptCompleted else { return }
-                    if let error {
-                        retryOrFail(error)
-                        return
+                    if let stopError {
+                        Logger.log(
+                            "Wake recovery: failed to stop stale Enhanced Mode core: \(stopError)",
+                            level: .warning
+                        )
                     }
 
-                    attemptCompleted = true
-                    self.isWakeEnhancedModeRestarting = false
-                    self.enhancedModeMenuItem.isEnabled = true
-                    self.enhancedModeMenuItem.state = .on
-                    Logger.log("Wake recovery: Enhanced Mode rebuilt successfully")
-                    self.scheduleEnhancedModePostToggleRefresh()
-                }
+                    ConfigManager.shared.isEnhancedModeActive = false
+                    self.refreshStatusItemViewStatus()
 
-                if wasActive {
-                    self.attemptEnableEnhancedMode(
-                        attemptsLeft: 1,
-                        alreadySuspended: true,
-                        completion: completion
-                    )
-                } else {
-                    self.enableEnhancedMode(completion: completion)
+                    let completion: (String?) -> Void = { [weak self] error in
+                        guard let self = self else { return }
+                        guard !attemptCompleted else { return }
+                        if let error {
+                            retryOrFail(error)
+                            return
+                        }
+
+                        attemptCompleted = true
+                        self.isWakeEnhancedModeRestarting = false
+                        self.enhancedModeMenuItem.isEnabled = true
+                        self.enhancedModeMenuItem.state = .on
+                        Logger.log("Wake recovery: Enhanced Mode rebuilt successfully")
+                        self.scheduleEnhancedModePostToggleRefresh()
+                    }
+
+                    if wasActive {
+                        self.attemptEnableEnhancedMode(
+                            attemptsLeft: 1,
+                            alreadySuspended: true,
+                            completion: completion
+                        )
+                    } else {
+                        self.enableEnhancedMode(completion: completion)
+                    }
                 }
             }
+        }
+
+        if wasActive {
+            restoreDNSAfterTun(
+                reapplyTunIfLate: true,
+                completion: stopAndRestart
+            )
+        } else {
+            stopAndRestart()
         }
     }
 
@@ -2217,6 +2241,10 @@ extension AppDelegate {
 
                 if listenersUp {
                     Logger.log("External core API + listeners ready on port \(port)")
+                    self.enhancedModeHealthGraceUntil = Date().addingTimeInterval(
+                        Self.enhancedModeHealthGracePeriod
+                    )
+                    self.consecutiveEnhancedModeHealthFailures = 0
                     ready(true)
                 } else if retriesLeft > 0 {
                     Logger.log("Waiting for external core listeners (\(retriesLeft) retries left)...", level: .debug)
@@ -2410,7 +2438,10 @@ extension AppDelegate {
         }
     }
 
-    private func restoreDNSAfterTun(completion: (() -> Void)? = nil) {
+    private func restoreDNSAfterTun(
+        reapplyTunIfLate: Bool = false,
+        completion: (() -> Void)? = nil
+    ) {
         guard let helper = PrivilegedHelperManager.shared.helper() else {
             completion?()
             return
@@ -2423,12 +2454,61 @@ extension AppDelegate {
         } else {
             restoreInfo = saved
         }
+
+        Logger.log("TUN DNS restore started")
+        var didFinish = false
+        var didTimeOut = false
+        let finish: (Bool) -> Void = { timedOut in
+            let finishOnMain = {
+                guard !didFinish else { return }
+                didFinish = true
+                didTimeOut = timedOut
+                if timedOut {
+                    Logger.log(
+                        "TUN DNS restore timed out after " +
+                            "\(Self.tunDNSRestoreTimeout)s; continuing recovery",
+                        level: .warning
+                    )
+                }
+                completion?()
+            }
+
+            if Thread.isMainThread {
+                finishOnMain()
+            } else {
+                DispatchQueue.main.async(execute: finishOnMain)
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.tunDNSRestoreTimeout) {
+            finish(true)
+        }
+
         helper.restoreDNS(withSavedInfo: restoreInfo,
                           filterInterface: Settings.filterInterface) { [weak self] _ in
-            self?.savedDNSInfo = [:]
-            helper.flushDNSCache { _ in
-                Logger.log("TUN DNS restored")
-                completion?()
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.savedDNSInfo = [:]
+                Logger.log("TUN DNS settings restored")
+
+                if didFinish {
+                    if didTimeOut,
+                       reapplyTunIfLate,
+                       ConfigManager.shared.isEnhancedModeActive {
+                        Logger.log(
+                            "Late TUN DNS restore completed after core recovery; " +
+                                "reapplying TUN DNS",
+                            level: .warning
+                        )
+                        self.overrideDNSForTun()
+                    }
+                    return
+                }
+
+                helper.flushDNSCache { _ in
+                    Logger.log("TUN DNS cache flushed")
+                    finish(false)
+                }
             }
         }
     }
@@ -2483,33 +2563,48 @@ extension AppDelegate {
         return []
     }
 
-    private func scheduleStaleMihomoCoreCleanupOnLaunch() {
-        guard Settings.enhancedMode else { return }
-        if PrivilegedHelperManager.shared.isHelperCheckFinished.value {
-            cleanupStaleMihomoCoreOnLaunch()
+    private func cleanupStaleMihomoCoreOnLaunch(completion: @escaping () -> Void) {
+        guard Settings.enhancedMode else {
+            completion()
+            return
+        }
+        guard !didCompleteStaleEnhancedCoreCleanup else {
+            completion()
+            return
+        }
+        Logger.log("Cleanup stale mihomo_core from previous session", level: .info)
+        var didFinish = false
+        let finish: (Bool) -> Void = { [weak self] timedOut in
+            DispatchQueue.main.async {
+                guard !didFinish else { return }
+                didFinish = true
+                if timedOut {
+                    Logger.log(
+                        "Stale mihomo_core cleanup timed out; continuing restore",
+                        level: .warning
+                    )
+                }
+                self?.didCompleteStaleEnhancedCoreCleanup = true
+                Logger.log("Stale mihomo_core cleanup finished")
+                completion()
+            }
+        }
+        guard let binaryPath = Bundle.main.path(forResource: "mihomo_core", ofType: nil) else {
+            finish(false)
+            return
+        }
+        guard let helper = PrivilegedHelperManager.shared.helper(failture: {
+            finish(false)
+        }) else {
+            finish(false)
             return
         }
 
-        PrivilegedHelperManager.shared.isHelperCheckFinished
-            .filter { $0 }
-            .take(1)
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] _ in
-                self?.cleanupStaleMihomoCoreOnLaunch()
-            })
-            .disposed(by: disposeBag)
-    }
-
-    private func cleanupStaleMihomoCoreOnLaunch() {
-        guard Settings.enhancedMode else { return }
-        guard !didCompleteStaleEnhancedCoreCleanup else { return }
-        didCompleteStaleEnhancedCoreCleanup = true
-        Logger.log("Cleanup stale mihomo_core from previous session", level: .info)
-        guard let binaryPath = Bundle.main.path(forResource: "mihomo_core", ofType: nil) else { return }
-        let semaphore = DispatchSemaphore(value: 0)
-        guard let helper = PrivilegedHelperManager.shared.helper(failture: {
-            semaphore.signal()
-        }) else { return }
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.staleEnhancedCoreCleanupTimeout
+        ) {
+            finish(true)
+        }
 
         helper.cleanupMihomoCore(
             withBinaryPath: binaryPath,
@@ -2519,14 +2614,35 @@ extension AppDelegate {
             if let error = error {
                 Logger.log("Stale mihomo_core cleanup failed: \(error)", level: .warning)
             }
-            semaphore.signal()
+            finish(false)
         }
-        _ = semaphore.wait(timeout: .now() + 3.0)
     }
 
     private func restoreEnhancedModeIfNeeded() {
         guard Settings.enhancedMode else { return }
-        restoreEnhancedMode(attemptsLeft: Self.enhancedModeRestoreMaxAttempts)
+        let prepareAndRestore = { [weak self] in
+            guard let self else { return }
+            self.cleanupStaleMihomoCoreOnLaunch { [weak self] in
+                self?.restoreEnhancedMode(
+                    attemptsLeft: Self.enhancedModeRestoreMaxAttempts
+                )
+            }
+        }
+
+        if PrivilegedHelperManager.shared.isHelperCheckFinished.value {
+            prepareAndRestore()
+            return
+        }
+
+        Logger.log("Waiting for helper before Enhanced Mode restore")
+        PrivilegedHelperManager.shared.isHelperCheckFinished
+            .filter { $0 }
+            .take(1)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { _ in
+                prepareAndRestore()
+            })
+            .disposed(by: disposeBag)
     }
 
     private func restoreEnhancedMode(attemptsLeft: Int) {
@@ -2791,43 +2907,100 @@ extension AppDelegate {
     private func runSpeedTest(benchmarkURL: String,
                               timeout: Int,
                               showNotifications: Bool) {
-        if isSpeedTesting {
-            if showNotifications {
-                NSUserNotificationCenter.default.postSpeedTestingNotice()
-            }
+        guard let session = beginSpeedTest(showNotifications: showNotifications) else {
             return
         }
-        if showNotifications {
-            NSUserNotificationCenter.default.postSpeedTestBeginNotice()
-        }
-
-        isSpeedTesting = true
 
         ApiRequest.getMergedProxyData { [weak self] resp in
             guard let self = self else { return }
+            guard !session.isCancelled else {
+                self.finishSpeedTest(
+                    session: session,
+                    showNotifications: showNotifications
+                )
+                return
+            }
             guard let resp = resp else {
-                self.finishSpeedTest(showNotifications: showNotifications)
+                self.finishSpeedTest(
+                    session: session,
+                    showNotifications: showNotifications
+                )
                 return
             }
 
             ApiRequest.benchmarkLeafProxies(
                 in: resp,
                 benchmarkURL: benchmarkURL,
-                timeout: timeout
+                timeout: timeout,
+                session: session
             ) {
-                ApiRequest.retestURLTestGroups(in: resp, timeout: timeout) {
-                    self.finishSpeedTest(showNotifications: showNotifications)
+                ApiRequest.retestURLTestGroups(
+                    in: resp,
+                    timeout: timeout,
+                    session: session
+                ) {
+                    self.finishSpeedTest(
+                        session: session,
+                        showNotifications: showNotifications
+                    )
                 }
             }
         }
     }
 
-    private func finishSpeedTest(showNotifications: Bool) {
+    func beginSpeedTest(showNotifications: Bool) -> ApiRequest.BenchmarkSession? {
+        guard !isWakeEnhancedModeRestarting else {
+            Logger.log(
+                "Benchmark blocked while Enhanced Mode recovery is in progress",
+                level: .warning
+            )
+            NSUserNotificationCenter.default.post(
+                title: NSLocalizedString("Benchmark", comment: ""),
+                info: NSLocalizedString(
+                    "Enhanced Mode is recovering. Please try again shortly.",
+                    comment: ""
+                )
+            )
+            return nil
+        }
+        guard !isSpeedTesting else {
+            if showNotifications {
+                NSUserNotificationCenter.default.postSpeedTestingNotice()
+            }
+            return nil
+        }
+
+        let session = ApiRequest.BenchmarkSession()
+        activeBenchmarkSession = session
+        isSpeedTesting = true
+        if showNotifications {
+            NSUserNotificationCenter.default.postSpeedTestBeginNotice()
+        }
+        return session
+    }
+
+    func finishSpeedTest(
+        session: ApiRequest.BenchmarkSession,
+        showNotifications: Bool
+    ) {
+        guard activeBenchmarkSession === session else { return }
+        activeBenchmarkSession = nil
         isSpeedTesting = false
         MenuItemFactory.refreshExistingMenuItems()
-        if showNotifications {
+        if showNotifications, !session.isCancelled {
             NSUserNotificationCenter.default.postSpeedTestFinishNotice()
         }
+    }
+
+    private func cancelActiveSpeedTestForCoreRecovery() {
+        guard let session = activeBenchmarkSession else { return }
+        Logger.log(
+            "Cancelling active benchmark before Enhanced Mode core recovery",
+            level: .warning
+        )
+        activeBenchmarkSession = nil
+        isSpeedTesting = false
+        session.cancel()
     }
 
     @IBAction func actionUpdateExternalResource(_ sender: Any) {

--- a/ClashFX/General/ApiRequest.swift
+++ b/ClashFX/General/ApiRequest.swift
@@ -64,7 +64,57 @@ private final class LimitedAsyncTaskRunner {
 }
 
 class ApiRequest {
+    final class BenchmarkSession {
+        private let lock = NSLock()
+        private var requests: [UUID: DataRequest] = [:]
+        private var cancelled = false
+
+        var isCancelled: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return cancelled
+        }
+
+        fileprivate func track(_ request: DataRequest) -> UUID {
+            let id = UUID()
+            lock.lock()
+            let shouldCancel = cancelled
+            if !shouldCancel {
+                requests[id] = request
+            }
+            lock.unlock()
+
+            if shouldCancel {
+                request.cancel()
+            }
+            return id
+        }
+
+        fileprivate func finish(_ id: UUID) {
+            lock.lock()
+            requests[id] = nil
+            lock.unlock()
+        }
+
+        func cancel() {
+            lock.lock()
+            guard !cancelled else {
+                lock.unlock()
+                return
+            }
+            cancelled = true
+            let pendingRequests = Array(requests.values)
+            requests.removeAll()
+            lock.unlock()
+
+            pendingRequests.forEach { $0.cancel() }
+        }
+    }
+
     static let shared = ApiRequest()
+    static let benchmarkMaxConcurrent = 8
+    private static let benchmarkRequestTimeoutMargin: TimeInterval = 5
+    private static let benchmarkMinimumRequestTimeout: TimeInterval = 10
 
     private var proxyRespCache: ClashProxyResp?
 
@@ -89,7 +139,8 @@ class ApiRequest {
         _ url: String,
         method: HTTPMethod = .get,
         parameters: Parameters? = nil,
-        encoding: ParameterEncoding = URLEncoding.default
+        encoding: ParameterEncoding = URLEncoding.default,
+        timeoutInterval: TimeInterval? = nil
     )
         -> DataRequest {
         guard ConfigManager.shared.isRunning else {
@@ -101,7 +152,12 @@ class ApiRequest {
                      method: method,
                      parameters: parameters,
                      encoding: encoding,
-                     headers: authHeader())
+                     headers: authHeader(),
+                     requestModifier: { request in
+                         if let timeoutInterval {
+                             request.timeoutInterval = timeoutInterval
+                         }
+                     })
     }
 
     weak var delegate: ApiRequestStreamDelegate?
@@ -389,12 +445,14 @@ class ApiRequest {
     static func getProxyDelay(proxyName: String,
                               benchmarkURL: String = Settings.benchMarkUrl,
                               timeout: Int = 5000,
+                              session: BenchmarkSession? = nil,
                               callback: @escaping ((Int) -> Void)) {
         requestProxyDelay(
             path: "/proxies/\(proxyName.encoded)/delay",
             description: "proxy '\(proxyName)'",
             benchmarkURL: benchmarkURL,
             timeout: timeout,
+            session: session,
             callback: callback
         )
     }
@@ -403,12 +461,14 @@ class ApiRequest {
                                       proxyName: ClashProxyName,
                                       benchmarkURL: String = Settings.benchMarkUrl,
                                       timeout: Int = 5000,
+                                      session: BenchmarkSession? = nil,
                                       callback: @escaping ((Int) -> Void)) {
         requestProxyDelay(
             path: "/providers/proxies/\(providerName.encoded)/\(proxyName.encoded)/healthcheck",
             description: "provider '\(providerName)' proxy '\(proxyName)'",
             benchmarkURL: benchmarkURL,
             timeout: timeout,
+            session: session,
             callback: callback
         )
     }
@@ -417,16 +477,33 @@ class ApiRequest {
                                    benchmarkURL: String = Settings.benchMarkUrl,
                                    expectedStatus: String? = nil,
                                    timeout: Int = 5000,
+                                   session: BenchmarkSession? = nil,
                                    callback: @escaping (([ClashProxyName: Int]) -> Void)) {
+        guard session?.isCancelled != true else {
+            callback([:])
+            return
+        }
         Logger.log("[Proxy Delay] Testing group '\(groupName)' with its configured URL")
         var parameters: Parameters = ["timeout": timeout, "url": benchmarkURL]
         if let expectedStatus, !expectedStatus.isEmpty {
             parameters["expected"] = expectedStatus
         }
-        req("/group/\(groupName.encoded)/delay",
+        let request = req(
+            "/group/\(groupName.encoded)/delay",
             method: .get,
-            parameters: parameters)
+            parameters: parameters,
+            timeoutInterval: benchmarkRequestTimeout(for: timeout)
+        )
+        let requestID = session?.track(request)
+        request
             .responseData { res in
+                if let requestID {
+                    session?.finish(requestID)
+                }
+                guard session?.isCancelled != true else {
+                    callback([:])
+                    return
+                }
                 let statusCode = res.response?.statusCode ?? -1
                 switch res.result {
                 case let .success(value) where (200 ..< 300).contains(statusCode):
@@ -453,7 +530,12 @@ class ApiRequest {
                                     limitedTo groupNames: Set<ClashProxyName>? = nil,
                                     timeout: Int,
                                     maxConcurrent: Int = 3,
+                                    session: BenchmarkSession? = nil,
                                     completion: @escaping () -> Void) {
+        guard session?.isCancelled != true else {
+            completion()
+            return
+        }
         typealias DelayTask = LimitedAsyncTaskRunner.Task
         let groups = response.proxyGroups.filter { group in
             group.type == .urltest && (groupNames == nil || groupNames?.contains(group.name) == true)
@@ -465,11 +547,16 @@ class ApiRequest {
 
         let tasks: [DelayTask] = groups.map { group in
             { done in
+                guard session?.isCancelled != true else {
+                    done()
+                    return
+                }
                 getProxyGroupDelay(
                     groupName: group.name,
                     benchmarkURL: group.testUrl ?? Settings.benchMarkUrl,
                     expectedStatus: group.expectedStatus,
-                    timeout: timeout
+                    timeout: timeout,
+                    session: session
                 ) { _ in
                     done()
                 }
@@ -485,8 +572,13 @@ class ApiRequest {
     static func benchmarkLeafProxies(in response: ClashProxyResp,
                                      benchmarkURL: String,
                                      timeout: Int,
-                                     maxConcurrent: Int = 10,
+                                     maxConcurrent: Int = benchmarkMaxConcurrent,
+                                     session: BenchmarkSession? = nil,
                                      completion: @escaping () -> Void) {
+        guard session?.isCancelled != true else {
+            completion()
+            return
+        }
         typealias DelayTask = LimitedAsyncTaskRunner.Task
         var tasks = [DelayTask]()
 
@@ -510,10 +602,15 @@ class ApiRequest {
 
         for proxy in inlineProxies where inlineProxyNames.insert(proxy.name).inserted {
             tasks.append { done in
+                guard session?.isCancelled != true else {
+                    done()
+                    return
+                }
                 getProxyDelay(
                     proxyName: proxy.name,
                     benchmarkURL: benchmarkURL,
-                    timeout: timeout
+                    timeout: timeout,
+                    session: session
                 ) { _ in
                     done()
                 }
@@ -532,11 +629,16 @@ class ApiRequest {
                 let key = provider.name + "\u{0}" + proxy.name
                 guard providerProxyKeys.insert(key).inserted else { continue }
                 tasks.append { done in
+                    guard session?.isCancelled != true else {
+                        done()
+                        return
+                    }
                     getProviderProxyDelay(
                         providerName: provider.name,
                         proxyName: proxy.name,
                         benchmarkURL: benchmarkURL,
-                        timeout: timeout
+                        timeout: timeout,
+                        session: session
                     ) { _ in
                         done()
                     }
@@ -552,16 +654,104 @@ class ApiRequest {
         LimitedAsyncTaskRunner(tasks: tasks, maxConcurrent: maxConcurrent).start(completion: completion)
     }
 
+    static func benchmarkProxySelection(
+        proxyNames: [ClashProxyName],
+        providerNames: Set<ClashProviderName>,
+        benchmarkURL: String,
+        timeout: Int,
+        maxConcurrent: Int = benchmarkMaxConcurrent,
+        session: BenchmarkSession,
+        proxyResult: @escaping (ClashProxyName, Int) -> Void,
+        completion: @escaping () -> Void
+    ) {
+        guard !session.isCancelled else {
+            completion()
+            return
+        }
+
+        typealias DelayTask = LimitedAsyncTaskRunner.Task
+        var tasks = [DelayTask]()
+        var uniqueProxyNames = Set<ClashProxyName>()
+
+        for proxyName in proxyNames where uniqueProxyNames.insert(proxyName).inserted {
+            tasks.append { done in
+                guard !session.isCancelled else {
+                    done()
+                    return
+                }
+                getProxyDelay(
+                    proxyName: proxyName,
+                    benchmarkURL: benchmarkURL,
+                    timeout: timeout,
+                    session: session
+                ) { delay in
+                    if !session.isCancelled {
+                        proxyResult(proxyName, delay)
+                    }
+                    done()
+                }
+            }
+        }
+
+        for providerName in providerNames.sorted() {
+            tasks.append { done in
+                guard !session.isCancelled else {
+                    done()
+                    return
+                }
+                healthCheck(
+                    proxy: providerName,
+                    requestTimeout: benchmarkRequestTimeout(for: timeout),
+                    session: session,
+                    completeHandler: done
+                )
+            }
+        }
+
+        Logger.log(
+            "[Proxy Delay] Starting selected benchmark: " +
+                "\(uniqueProxyNames.count) inline, \(providerNames.count) provider, " +
+                "max concurrency \(max(1, maxConcurrent))"
+        )
+        LimitedAsyncTaskRunner(tasks: tasks, maxConcurrent: maxConcurrent)
+            .start(completion: completion)
+    }
+
+    private static func benchmarkRequestTimeout(for coreTimeoutMilliseconds: Int) -> TimeInterval {
+        max(
+            benchmarkMinimumRequestTimeout,
+            Double(coreTimeoutMilliseconds) / 1000 + benchmarkRequestTimeoutMargin
+        )
+    }
+
     private static func requestProxyDelay(path: String,
                                           description: String,
                                           benchmarkURL: String,
                                           timeout: Int,
+                                          session: BenchmarkSession?,
                                           callback: @escaping ((Int) -> Void)) {
+        guard session?.isCancelled != true else {
+            callback(0)
+            return
+        }
         Logger.log("[Proxy Delay] Testing \(description) with url: \(benchmarkURL)")
-        req(path,
+        let request = req(
+            path,
             method: .get,
-            parameters: ["timeout": timeout, "url": benchmarkURL])
+            parameters: ["timeout": timeout, "url": benchmarkURL],
+            timeoutInterval: benchmarkRequestTimeout(for: timeout)
+        )
+        let requestID = session?.track(request)
+        request
             .responseData { res in
+                if let requestID {
+                    session?.finish(requestID)
+                }
+                guard session?.isCancelled != true else {
+                    Logger.log("[Proxy Delay] Cancelled \(description)", level: .debug)
+                    callback(0)
+                    return
+                }
                 let statusCode = res.response?.statusCode ?? -1
                 switch res.result {
                 case let .success(value):
@@ -590,9 +780,30 @@ class ApiRequest {
         }
     }
 
-    static func healthCheck(proxy: ClashProviderName, completeHandler: (() -> Void)? = nil) {
+    static func healthCheck(
+        proxy: ClashProviderName,
+        requestTimeout: TimeInterval? = nil,
+        session: BenchmarkSession? = nil,
+        completeHandler: (() -> Void)? = nil
+    ) {
+        guard session?.isCancelled != true else {
+            completeHandler?()
+            return
+        }
         Logger.log("HeathCheck for \(proxy) started")
-        req("/providers/proxies/\(proxy.encoded)/healthcheck").response { res in
+        let request = req(
+            "/providers/proxies/\(proxy.encoded)/healthcheck",
+            timeoutInterval: requestTimeout
+        )
+        let requestID = session?.track(request)
+        request.response { res in
+            if let requestID {
+                session?.finish(requestID)
+            }
+            guard session?.isCancelled != true else {
+                completeHandler?()
+                return
+            }
             if res.response?.statusCode == 204 {
                 Logger.log("HeathCheck for \(proxy) finished")
             } else {

--- a/ClashFX/General/Managers/PrivilegedHelperManager.swift
+++ b/ClashFX/General/Managers/PrivilegedHelperManager.swift
@@ -9,6 +9,7 @@
 import AppKit
 import RxCocoa
 import RxSwift
+import Security
 import ServiceManagement
 
 class PrivilegedHelperManager {
@@ -21,6 +22,13 @@ class PrivilegedHelperManager {
     private let connectionLock = NSLock()
     static let machServiceName = "com.clashfx.app.Helper"
     static let shared = PrivilegedHelperManager()
+    // Keep this longer than the helper's initial connection grace period so
+    // the app cannot reinstall a helper that is still waiting for launchd to
+    // deliver the XPC request.
+    private static let installedHelperResponseTimeout: TimeInterval = 75
+    private static let missingHelperResponseTimeout: TimeInterval = 5
+    private static let adHocSignatureFlag: UInt32 = 0x2
+
     init() {
         initAuthorizationRef()
     }
@@ -85,6 +93,30 @@ class PrivilegedHelperManager {
             Logger.log("initAuthorizationRef AuthorizationCreate failed", level: .error)
             return
         }
+    }
+
+    private func currentAppUsesAdHocSignature() -> Bool {
+        var staticCode: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(
+            Bundle.main.bundleURL as CFURL,
+            [],
+            &staticCode
+        ) == errSecSuccess, let staticCode else {
+            return false
+        }
+
+        var signingInfo: CFDictionary?
+        guard SecCodeCopySigningInformation(
+            staticCode,
+            SecCSFlags(rawValue: kSecCSSigningInformation),
+            &signingInfo
+        ) == errSecSuccess,
+            let info = signingInfo as? [String: Any],
+            let flags = info[kSecCodeInfoFlags as String] as? NSNumber else {
+            return false
+        }
+
+        return flags.uint32Value & Self.adHocSignatureFlag != 0
     }
 
     /// Install new helper daemon
@@ -230,12 +262,25 @@ class PrivilegedHelperManager {
             finish(.noFound)
             return
         }
-        let helperFileExists = FileManager.default.fileExists(atPath: "/Library/PrivilegedHelperTools/\(PrivilegedHelperManager.machServiceName)")
+        let installedHelperURL = URL(
+            fileURLWithPath: "/Library/PrivilegedHelperTools/\(PrivilegedHelperManager.machServiceName)"
+        )
+        let helperFileExists = FileManager.default.fileExists(atPath: installedHelperURL.path)
         if !helperFileExists {
             finish(.noFound)
             return
         }
-        let timeout: TimeInterval = helperFileExists ? 15 : 5
+        if !FileManager.default.contentsEqual(
+            atPath: helperURL.path,
+            andPath: installedHelperURL.path
+        ) {
+            Logger.log("Installed helper differs from bundled helper; update required")
+            finish(.needUpdate)
+            return
+        }
+        let timeout = helperFileExists
+            ? Self.installedHelperResponseTimeout
+            : Self.missingHelperResponseTimeout
         let time = Date()
 
         timer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { _ in
@@ -293,8 +338,12 @@ extension PrivilegedHelperManager {
             return
         }
 
-        if useLegacyInstall {
+        if useLegacyInstall || currentAppUsesAdHocSignature() {
             useLegacyInstall = false
+            Logger.log(
+                "Using legacy helper installation for an ad-hoc signed app",
+                level: .info
+            )
             legacyInstallHelper()
             if !cancelInstallCheck {
                 checkInstall()

--- a/ClashFX/General/Managers/Settings.swift
+++ b/ClashFX/General/Managers/Settings.swift
@@ -207,13 +207,20 @@ enum Settings {
 
     static let disableShowCurrentProxyInMenu = !AppDelegate.isAboveMacOS14
 
-    static let defaultBenchmarkUrl = "http://cp.cloudflare.com/generate_204"
+    private static let legacyDefaultBenchmarkUrl = "http://cp.cloudflare.com/generate_204"
+    static let defaultBenchmarkUrl = "https://cp.cloudflare.com/generate_204"
     @UserDefault("benchMarkUrl", defaultValue: defaultBenchmarkUrl)
     static var benchMarkUrl: String {
         didSet {
             if benchMarkUrl.isEmpty {
                 benchMarkUrl = defaultBenchmarkUrl
             }
+        }
+    }
+
+    static func migrateLegacyBenchmarkURLIfNeeded() {
+        if benchMarkUrl == legacyDefaultBenchmarkUrl {
+            benchMarkUrl = defaultBenchmarkUrl
         }
     }
 

--- a/ClashFX/Views/ProxyGroupSpeedTestMenuItem.swift
+++ b/ClashFX/Views/ProxyGroupSpeedTestMenuItem.swift
@@ -52,6 +52,9 @@ class ProxyGroupSpeedTestMenuItem: NSMenuItem {
     func retestAutoGroup() {
         guard testType == .reTest else { return }
         guard !isTesting else { return }
+        guard let session = AppDelegate.shared.beginSpeedTest(showNotifications: false) else {
+            return
+        }
 
         isTesting = true
         isEnabled = false
@@ -60,9 +63,14 @@ class ProxyGroupSpeedTestMenuItem: NSMenuItem {
         ApiRequest.getProxyGroupDelay(
             groupName: proxyGroup.name,
             benchmarkURL: proxyGroup.testUrl ?? Settings.benchMarkUrl,
-            expectedStatus: proxyGroup.expectedStatus
+            expectedStatus: proxyGroup.expectedStatus,
+            session: session
         ) { _ in
             DispatchQueue.main.async {
+                AppDelegate.shared.finishSpeedTest(
+                    session: session,
+                    showNotifications: false
+                )
                 self.isTesting = false
                 self.isEnabled = true
                 self.updateViewTitle(self.testType.title)
@@ -136,9 +144,13 @@ private class ProxyGroupSpeedTestMenuItemView: MenuItemBaseView {
     }
 
     private func startBenchmark() {
-        guard let group = (enclosingMenuItem as? ProxyGroupSpeedTestMenuItem)?.proxyGroup
-        else { return }
-        let testGroup = DispatchGroup()
+        guard let speedTestItem = enclosingMenuItem as? ProxyGroupSpeedTestMenuItem else {
+            return
+        }
+        let group = speedTestItem.proxyGroup
+        guard let session = AppDelegate.shared.beginSpeedTest(showNotifications: false) else {
+            return
+        }
 
         var proxies = [ClashProxyName]()
         var providers = Set<ClashProviderName>()
@@ -151,50 +163,52 @@ private class ProxyGroupSpeedTestMenuItemView: MenuItemBaseView {
             }
         }
 
-        for proxyName in proxies {
-            testGroup.enter()
-            ApiRequest.getProxyDelay(proxyName: proxyName) { delay in
+        label.stringValue = NSLocalizedString("Testing", comment: "")
+        speedTestItem.isEnabled = false
+        setNeedsDisplay()
+
+        let finish = { [weak self, weak speedTestItem] in
+            AppDelegate.shared.finishSpeedTest(
+                session: session,
+                showNotifications: false
+            )
+            guard let self, let menu = speedTestItem else { return }
+            self.label.stringValue = menu.title
+            menu.isEnabled = true
+            self.setNeedsDisplay()
+            MenuItemFactory.refreshExistingMenuItems()
+        }
+
+        ApiRequest.benchmarkProxySelection(
+            proxyNames: proxies,
+            providerNames: providers,
+            benchmarkURL: Settings.benchMarkUrl,
+            timeout: 5000,
+            session: session,
+            proxyResult: { proxyName, delay in
                 let delayStr = delay == 0 ? NSLocalizedString("fail", comment: "") : "\(delay) ms"
                 NotificationCenter.default.post(name: .speedTestFinishForProxy,
                                                 object: nil,
                                                 userInfo: ["proxyName": proxyName, "delay": delayStr, "rawValue": delay])
-                testGroup.leave()
+            },
+            completion: {
+                guard !session.isCancelled else {
+                    finish()
+                    return
+                }
+                guard let response = group.enclosingResp else {
+                    finish()
+                    return
+                }
+                ApiRequest.retestURLTestGroups(
+                    in: response,
+                    limitedTo: Set(group.all ?? []),
+                    timeout: 5000,
+                    session: session,
+                    completion: finish
+                )
             }
-        }
-
-        label.stringValue = NSLocalizedString("Testing", comment: "")
-        enclosingMenuItem?.isEnabled = false
-        setNeedsDisplay()
-
-        for provider in providers {
-            testGroup.enter()
-
-            ApiRequest.healthCheck(proxy: provider) {
-                testGroup.leave()
-            }
-        }
-
-        testGroup.notify(queue: .main) {
-            [weak self] in
-            guard let self = self, let menu = self.enclosingMenuItem else { return }
-            let finish = {
-                self.label.stringValue = menu.title
-                menu.isEnabled = true
-                self.setNeedsDisplay()
-                MenuItemFactory.refreshExistingMenuItems()
-            }
-
-            guard let response = group.enclosingResp else {
-                finish()
-                return
-            }
-            ApiRequest.retestURLTestGroups(
-                in: response,
-                limitedTo: Set(group.all ?? []),
-                timeout: 5000,
-                completion: finish
-            )
-        }
+        )
     }
 }
 

--- a/ProxyConfigHelper/Helper-Info.plist
+++ b/ProxyConfigHelper/Helper-Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleName</key>
 	<string>com.clashfx.app.Helper</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1</string>
+	<string>1.2</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>anchor apple generic and identifier &quot;com.clashfx.app&quot; and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MEWHFZ92DY)</string>

--- a/ProxyConfigHelper/ProxyConfigHelper.m
+++ b/ProxyConfigHelper/ProxyConfigHelper.m
@@ -9,7 +9,9 @@
 #import "ProxyConfigHelper.h"
 #import <AppKit/AppKit.h>
 #import <Security/Security.h>
+#import <libproc.h>
 #import <signal.h>
+#import <string.h>
 #import <unistd.h>
 #import "ProxyConfigRemoteProcessProtocol.h"
 #import "ProxySettingTool.h"
@@ -23,6 +25,7 @@ ProxyConfigRemoteProcessProtocol
 @property (nonatomic, strong) NSXPCListener *listener;
 @property (nonatomic, strong) NSMutableSet<NSXPCConnection *> *connections;
 @property (nonatomic, strong) NSTimer *checkTimer;
+@property (nonatomic, strong) NSTimer *idleExitTimer;
 @property (nonatomic, assign) BOOL shouldQuit;
 @property (nonatomic, strong) NSTask *mihomoTask;
 
@@ -38,6 +41,53 @@ ProxyConfigRemoteProcessProtocol
 
 static const NSTimeInterval kMihomoGracefulStopTimeout = 2.0;
 static const unsigned long long kMihomoCoreLogMaximumBytes = 4 * 1024 * 1024;
+static const NSTimeInterval kDNSCacheCommandTimeout = 2.0;
+// Give a newly launched ClashFX instance enough time to attach before an
+// invalidated connection from the previous instance lets the helper exit.
+static const NSTimeInterval kIdleExitGracePeriod = 10.0;
+// launchd can start the helper well before the original XPC request is
+// delivered when the system is under heavy load. Five seconds caused the
+// helper to exit cleanly before ClashFX could connect, which in turn made the
+// app repeatedly reinstall an already healthy helper.
+static const NSTimeInterval kInitialConnectionGracePeriod = 60.0;
+
+static BOOL RunTaskWithTimeout(NSString *executablePath,
+                               NSArray<NSString *> *arguments,
+                               NSTimeInterval timeout) {
+    NSTask *task = [[NSTask alloc] init];
+    task.executableURL = [NSURL fileURLWithPath:executablePath];
+    task.arguments = arguments;
+
+    NSError *launchError = nil;
+    if (![task launchAndReturnError:&launchError]) {
+        NSLog(@"DNS cache command failed to launch (%@): %@",
+              executablePath.lastPathComponent,
+              launchError.localizedDescription);
+        return NO;
+    }
+
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeout];
+    while (task.isRunning && deadline.timeIntervalSinceNow > 0) {
+        usleep(50 * 1000);
+    }
+    if (!task.isRunning) {
+        return task.terminationStatus == 0;
+    }
+
+    NSLog(@"DNS cache command timed out after %.1fs: %@",
+          timeout,
+          executablePath.lastPathComponent);
+    [task terminate];
+
+    NSDate *terminationDeadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
+    while (task.isRunning && terminationDeadline.timeIntervalSinceNow > 0) {
+        usleep(50 * 1000);
+    }
+    if (task.isRunning) {
+        kill(task.processIdentifier, SIGKILL);
+    }
+    return NO;
+}
 
 - (instancetype)init {
     
@@ -162,7 +212,11 @@ static const unsigned long long kMihomoCoreLogMaximumBytes = 4 * 1024 * 1024;
 - (void)run {
     [self.listener resume];
     self.checkTimer =
-    [NSTimer timerWithTimeInterval:5.f target:self selector:@selector(connectionCheckOnLaunch) userInfo:nil repeats:NO];
+    [NSTimer timerWithTimeInterval:kInitialConnectionGracePeriod
+                            target:self
+                          selector:@selector(connectionCheckOnLaunch)
+                          userInfo:nil
+                           repeats:NO];
     [[NSRunLoop currentRunLoop] addTimer:self.checkTimer forMode:NSDefaultRunLoopMode];
     while (!self.shouldQuit) {
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:2.0]];
@@ -175,9 +229,47 @@ static const unsigned long long kMihomoCoreLogMaximumBytes = 4 * 1024 * 1024;
     }
 }
 
+- (void)cancelIdleExit {
+    void (^cancel)(void) = ^{
+        [self.idleExitTimer invalidate];
+        self.idleExitTimer = nil;
+    };
+    if (NSThread.isMainThread) {
+        cancel();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), cancel);
+    }
+}
+
+- (void)scheduleIdleExitIfNeeded {
+    dispatch_block_t schedule = ^{
+        [self.idleExitTimer invalidate];
+        __weak ProxyConfigHelper *weakSelf = self;
+        self.idleExitTimer =
+        [NSTimer scheduledTimerWithTimeInterval:kIdleExitGracePeriod
+                                        repeats:NO
+                                          block:^(NSTimer *timer) {
+            ProxyConfigHelper *strongSelf = weakSelf;
+            if (!strongSelf) {
+                return;
+            }
+            strongSelf.idleExitTimer = nil;
+            if (strongSelf.connections.count == 0 &&
+                !(strongSelf.mihomoTask && strongSelf.mihomoTask.isRunning)) {
+                NSLog(@"Helper idle grace elapsed; exiting");
+                strongSelf.shouldQuit = YES;
+            }
+        }];
+    };
+    if (NSThread.isMainThread) {
+        schedule();
+    } else {
+        dispatch_async(dispatch_get_main_queue(), schedule);
+    }
+}
+
 - (BOOL)connectionIsValid: (NSXPCConnection *)connection {
     pid_t pid = connection.processIdentifier;
-    NSRunningApplication *remoteApp = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
     NSString *requirementString = [self authorizedClientRequirement];
     if (requirementString.length == 0) {
         NSLog(@"Rejected XPC client because helper has no authorized client requirement");
@@ -185,8 +277,31 @@ static const unsigned long long kMihomoCoreLogMaximumBytes = 4 * 1024 * 1024;
     }
 
     NSString *authorizedBundleIdentifier = [self authorizedClientBundleIdentifierFromRequirement:requirementString];
-    if (authorizedBundleIdentifier.length == 0 || ![remoteApp.bundleIdentifier isEqualToString:authorizedBundleIdentifier]) {
-        NSLog(@"Rejected XPC client with pid %d and bundle id %@", pid, remoteApp.bundleIdentifier);
+    char executablePathBuffer[PROC_PIDPATHINFO_MAXSIZE] = {0};
+    int executablePathLength = proc_pidpath(pid, executablePathBuffer, sizeof(executablePathBuffer));
+    if (executablePathLength <= 0) {
+        NSLog(@"Rejected XPC client because executable path lookup failed for pid %d", pid);
+        return NO;
+    }
+
+    NSString *executablePath = [[NSFileManager defaultManager]
+        stringWithFileSystemRepresentation:executablePathBuffer
+                                    length:strnlen(executablePathBuffer, sizeof(executablePathBuffer))];
+    NSURL *executableURL = [NSURL fileURLWithPath:executablePath];
+    NSURL *bundleURL = [[[executableURL URLByDeletingLastPathComponent]
+        URLByDeletingLastPathComponent] URLByDeletingLastPathComponent];
+    NSBundle *clientBundle = [NSBundle bundleWithURL:bundleURL];
+
+    BOOL hasExpectedBundleLayout =
+        [bundleURL.pathExtension caseInsensitiveCompare:@"app"] == NSOrderedSame &&
+        [executableURL.lastPathComponent isEqualToString:@"ClashFX"] &&
+        [executableURL.path hasPrefix:
+            [bundleURL.path stringByAppendingPathComponent:@"Contents/MacOS/"]];
+    if (authorizedBundleIdentifier.length == 0 ||
+        !hasExpectedBundleLayout ||
+        ![clientBundle.bundleIdentifier isEqualToString:authorizedBundleIdentifier]) {
+        NSLog(@"Rejected XPC client with pid %d, bundle id %@, executable %@",
+              pid, clientBundle.bundleIdentifier, executablePath);
         return NO;
     }
 
@@ -221,10 +336,9 @@ static const unsigned long long kMihomoCoreLogMaximumBytes = 4 * 1024 * 1024;
         // cannot satisfy. Bundle ID was already validated above; accept the
         // connection if the executable matches a ClashFX .app bundle.
         // TODO(#65): remove once releases ship with a Developer ID signature.
-        if ([remoteApp.bundleURL.pathExtension isEqualToString:@"app"] &&
-            [remoteApp.executableURL.lastPathComponent isEqualToString:@"ClashFX"]) {
+        if (hasExpectedBundleLayout) {
             NSLog(@"Allowing XPC client with ad-hoc signature (pid=%d, bundle=%@)",
-                  pid, remoteApp.bundleIdentifier);
+                  pid, clientBundle.bundleIdentifier);
             return YES;
         }
         NSLog(@"Rejected XPC client because code signature validation failed: %d", status);
@@ -274,12 +388,29 @@ static const unsigned long long kMihomoCoreLogMaximumBytes = 4 * 1024 * 1024;
     __weak NSXPCConnection *weakConnection = newConnection;
     __weak ProxyConfigHelper *weakSelf = self;
     newConnection.invalidationHandler = ^{
-        [weakSelf.connections removeObject:weakConnection];
-        if (weakSelf.connections.count == 0 && !(weakSelf.mihomoTask && weakSelf.mihomoTask.isRunning)) {
-            weakSelf.shouldQuit = YES;
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            ProxyConfigHelper *strongSelf = weakSelf;
+            NSXPCConnection *strongConnection = weakConnection;
+            if (!strongSelf) {
+                return;
+            }
+            if (strongConnection) {
+                [strongSelf.connections removeObject:strongConnection];
+            }
+            if (strongSelf.connections.count == 0) {
+                [strongSelf scheduleIdleExitIfNeeded];
+            }
+        });
     };
-    [self.connections addObject:newConnection];
+    [self cancelIdleExit];
+    void (^registerConnection)(void) = ^{
+        [self.connections addObject:newConnection];
+    };
+    if (NSThread.isMainThread) {
+        registerConnection();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), registerConnection);
+    }
     [newConnection resume];
     return YES;
 }
@@ -473,19 +604,22 @@ static const unsigned long long kMihomoCoreLogMaximumBytes = 4 * 1024 * 1024;
 
 - (void)flushDNSCacheWithReply:(stringReplyBlock)reply {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        NSTask *flush = [[NSTask alloc] init];
-        flush.executableURL = [NSURL fileURLWithPath:@"/usr/bin/dscacheutil"];
-        flush.arguments = @[@"-flushcache"];
-        [flush launchAndReturnError:nil];
-        [flush waitUntilExit];
+        BOOL flushSucceeded = RunTaskWithTimeout(
+            @"/usr/bin/dscacheutil",
+            @[@"-flushcache"],
+            kDNSCacheCommandTimeout
+        );
+        BOOL hupSucceeded = RunTaskWithTimeout(
+            @"/usr/bin/killall",
+            @[@"-HUP", @"mDNSResponder"],
+            kDNSCacheCommandTimeout
+        );
 
-        NSTask *hup = [[NSTask alloc] init];
-        hup.executableURL = [NSURL fileURLWithPath:@"/usr/bin/killall"];
-        hup.arguments = @[@"-HUP", @"mDNSResponder"];
-        [hup launchAndReturnError:nil];
-        [hup waitUntilExit];
-
-        reply(nil);
+        if (flushSucceeded && hupSucceeded) {
+            reply(nil);
+        } else {
+            reply(@"DNS cache refresh timed out or failed");
+        }
     });
 }
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,23 @@
 ### Bug Fixes
 
+- **Large Delay Tests No Longer Trigger Enhanced Mode Restarts** — Manual benchmarks now share a bounded eight-request queue, cancel cleanly before recovery, and use control-plane health thresholds that tolerate short load spikes. Testing a large proxy group can no longer starve the controller and make ClashFX rebuild a healthy core. The default benchmark endpoint also uses HTTPS, with existing default settings migrated automatically.
+- **Helper Upgrades No Longer Loop or Race App Startup** — ClashFX now compares the bundled and installed Helper reliably, gives privileged operations enough time to finish, validates connecting clients, and keeps the Helper alive briefly while the app reconnects. Startup waits for Helper cleanup before restoring Enhanced Mode, preventing repeated installer prompts and transient “Helper unavailable” failures.
+- **Network Restoration Cannot Freeze Relaunch** — DNS restoration and cache flushing now have strict watchdogs, so a slow system command cannot stall ClashFX for minutes. If an older restore finishes late, the active proxy DNS settings are reapplied instead of being overwritten.
+
+---
+
+### 修复
+
+- **大批量延迟测速不再触发增强模式重启** — 手动测速现在统一使用最多八个并发请求的队列，恢复前会取消仍在进行的测速，并采用可容忍短时负载峰值的控制面健康阈值。测试大型策略组时不会再因控制接口被挤占而误判并重建健康核心。默认测速地址也已改为 HTTPS，旧的默认设置会自动迁移。
+- **Helper 升级不再反复弹窗或与应用启动竞争** — ClashFX 现在会可靠比较内置与已安装的 Helper，为特权操作保留充足完成时间，校验连接客户端，并在应用重连期间让 Helper 短暂保持运行。启动时会先等待 Helper 清理残留核心，再恢复增强模式，避免安装程序重复弹出及瞬时“Helper 不可用”失败。
+- **网络恢复不会再卡住应用重启** — DNS 恢复与缓存刷新现在都有严格的超时保护，缓慢的系统命令不会让 ClashFX 卡住数分钟。若旧恢复任务延迟完成，应用会重新应用当前代理 DNS 设置，避免覆盖正在使用的网络配置。
+
+<!-- Previous release notes -->
+
+---
+
+### Bug Fixes
+
 - **Enhanced Mode Startup Errors Are Now Actionable** — Failed Enhanced Mode toggles now show a prominent error dialog even when reduced notifications are enabled. Invalid TUN route-exclude entries are identified directly, with guidance to separate entries correctly and a shortcut to open Settings. (#190)
 
 ### Contributors


### PR DESCRIPTION
## What

- bound manual proxy benchmarks to eight concurrent requests, share/cancel benchmark sessions, and migrate the default delay-test endpoint to HTTPS
- harden Enhanced Mode health checks and startup sequencing so transient controller pressure does not rebuild a healthy core
- make DNS restoration/cache flushing time-bounded and protect active proxy DNS settings from late restore completion
- make privileged Helper upgrades and reconnects reliable through content comparison, longer operation timeouts, client validation, and a short idle handoff grace period
- bump the Helper bundle version and add bilingual Lab release notes

## Why

A 141-node manual delay test could saturate the local controller. Configuration health requests then timed out and the monitor rebuilt a healthy external core. Separately, DNS cache flushing could block relaunch for minutes, while the Helper's short lifetime and startup cleanup ordering caused transient XPC failures and repeated installer prompts.

## Impact

Large delay tests remain responsive without interrupting Enhanced Mode. App relaunch and network restoration are bounded, and Helper installation should occur only when the bundled binary actually changes. Existing custom benchmark URLs remain unchanged.

## Checks

- Release universal build (arm64 + x86_64) succeeds
- git diff --check passes
- SwiftFormat passes
- SwiftLint: 0 serious violations (59 warnings)
- 141-node selected benchmark: 141 started / 141 completed, controller probes 10/10 HTTP 200, core PID stable through the test and five subsequent monitoring cycles
- final restart: existing Helper PID remained stable, DNS restoration completed in ~0.27 s, stale-core cleanup completed before Enhanced Mode restore, controller probes 10/10 HTTP 200, and no installer/XPC/restore failure was logged