### PR TITLE
fix: recover enhanced mode data-plane stalls

### DIFF
--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -16,6 +16,7 @@ import KeyboardShortcuts
 import LetsMove
 import RxCocoa
 import RxSwift
+import SystemConfiguration
 import Yams
 
 let statusItemLengthWithSpeed: CGFloat = 65
@@ -36,6 +37,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private enum WakeCoreHealth {
         case healthy
         case unhealthy(String)
+    }
+
+    private enum EnhancedModeDataPlaneHealth {
+        case healthy(delay: Int)
+        case coreUnavailable(String)
+        case networkUnavailable(coreReason: String, directReason: String)
+    }
+
+    private struct EnhancedModeDataPlaneProbeContext {
+        let urls: [String]
+        var index: Int
+        var coreFailureReasons: [String]
+        var directFailureReasons: [String]
     }
 
     private struct TunInterfaceState {
@@ -137,9 +151,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var enhancedModeHealthTimer: Timer?
     private var isEnhancedModeHealthCheckInFlight = false
     private var consecutiveEnhancedModeHealthFailures = 0
+    private var consecutiveEnhancedModeDataPlaneFailures = 0
     private var enhancedModeHealthGraceUntil = Date.distantPast
+    private var lastEnhancedModeDataPlaneProbeAt = Date.distantPast
+    private var lastEnhancedModeDataPlaneRecoveryTime = Date.distantPast
+    private var isEnhancedModeRuntimeRecoveryPending = false
+    private(set) var enhancedModeRuntimeHealthSummary = "not checked"
     private var lastCoreLogRecoveryTime = Date.distantPast
     private var didCompleteStaleEnhancedCoreCleanup = false
+    private var didRestartHelperDuringEnhancedLaunch = false
     private var outboundModeRequestSequence = 0
     private var latestOutboundModeRequestID = 0
     private var outboundModeChangeQueue: [OutboundModeChangeRequest] = []
@@ -159,10 +179,42 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private static let enhancedModeHealthFailureThreshold = 3
     private static let enhancedModeHealthGracePeriod: TimeInterval = 60
     private static let enhancedModeHealthRequestTimeout: TimeInterval = 5
+    private static let enhancedModeDataPlaneProbeInterval: TimeInterval = 60
+    private static let enhancedModeDataPlaneProbeTimeoutMilliseconds = 5000
+    private static let enhancedModeDataPlaneProbeRequestTimeout: TimeInterval = 8
+    private static let enhancedModeDataPlaneFailureThreshold = 3
+    private static let enhancedModeDataPlaneRecoveryCooldown: TimeInterval = 10 * 60
+    /// Literal-IP endpoints keep the system-direct baseline independent from
+    /// Mihomo DNS. Each endpoint is tested through core DIRECT first and, only
+    /// on failure, through ClashFX Networking's generated DIRECT exemption.
+    private static let enhancedModeDataPlaneProbeURLs = [
+        "http://223.5.5.5/",
+        "http://1.1.1.1/cdn-cgi/trace"
+    ]
+    private static let enhancedModeDNSProbeName = "example.com"
+    private static let enhancedModeHelperRestartDelay: TimeInterval = 1
+    private static let enhancedModeDiagnosticTimeout: TimeInterval = 8
+    private static let enhancedModeHelperRequestTimeout: TimeInterval = 5
     private static let tunDNSRestoreTimeout: TimeInterval = 8
     private static let staleEnhancedCoreCleanupTimeout: TimeInterval = 3
     private static let fatalTunRecoveryCooldown: TimeInterval = 30
     private static let runtimePatchedConfigPath = kConfigFolderPath + ".runtime_config.yaml"
+
+    private lazy var enhancedModeHealthURLSession: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        configuration.timeoutIntervalForRequest = Self.enhancedModeDataPlaneProbeRequestTimeout
+        configuration.timeoutIntervalForResource = Self.enhancedModeDataPlaneProbeRequestTimeout
+        configuration.waitsForConnectivity = false
+        configuration.connectionProxyDictionary = [
+            kCFNetworkProxiesHTTPEnable as String: false,
+            kCFNetworkProxiesHTTPSEnable as String: false,
+            kCFNetworkProxiesSOCKSEnable as String: false,
+            kCFNetworkProxiesProxyAutoConfigEnable as String: false,
+            kCFNetworkProxiesProxyAutoDiscoveryEnable as String: false
+        ]
+        return URLSession(configuration: configuration)
+    }()
 
     /// Short-circuits TerminalConfirmAction during self-relaunch so the old
     /// status bar icon does not linger on "Quitting…" beside the new one (#84 #91).
@@ -1297,13 +1349,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func checkEnhancedModeRuntimeHealth() {
         guard Settings.enhancedMode,
               ConfigManager.shared.isEnhancedModeActive,
-              enhancedModeMenuItem.isEnabled,
-              !isWakeEnhancedModeRestarting else {
+              enhancedModeMenuItem.isEnabled else {
             consecutiveEnhancedModeHealthFailures = 0
+            consecutiveEnhancedModeDataPlaneFailures = 0
+            enhancedModeRuntimeHealthSummary = Settings.enhancedMode
+                ? "enabled preference; runtime not active"
+                : "inactive"
             return
         }
+        guard !isWakeEnhancedModeRestarting,
+              !isEnhancedModeRuntimeRecoveryPending else { return }
         guard Date() >= enhancedModeHealthGraceUntil else {
             consecutiveEnhancedModeHealthFailures = 0
+            consecutiveEnhancedModeDataPlaneFailures = 0
             return
         }
         guard !isEnhancedModeHealthCheckInFlight else { return }
@@ -1311,13 +1369,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         isEnhancedModeHealthCheckInFlight = true
         checkCoreHealthAfterWake { [weak self] health in
             guard let self = self else { return }
-            self.isEnhancedModeHealthCheckInFlight = false
 
             guard Settings.enhancedMode,
                   ConfigManager.shared.isEnhancedModeActive,
                   self.enhancedModeMenuItem.isEnabled,
-                  !self.isWakeEnhancedModeRestarting else {
+                  !self.isWakeEnhancedModeRestarting,
+                  !self.isEnhancedModeRuntimeRecoveryPending else {
+                self.isEnhancedModeHealthCheckInFlight = false
                 self.consecutiveEnhancedModeHealthFailures = 0
+                self.consecutiveEnhancedModeDataPlaneFailures = 0
                 return
             }
 
@@ -1325,11 +1385,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             case .healthy:
                 if self.consecutiveEnhancedModeHealthFailures > 0 {
                     Logger.log("Enhanced Mode runtime health recovered")
+                    self.enhancedModeRuntimeHealthSummary =
+                        "control plane recovered; awaiting data-plane probe"
                 }
                 self.consecutiveEnhancedModeHealthFailures = 0
+                self.checkEnhancedModeDataPlaneIfDue()
             case let .unhealthy(reason):
+                self.isEnhancedModeHealthCheckInFlight = false
+                self.consecutiveEnhancedModeDataPlaneFailures = 0
                 self.consecutiveEnhancedModeHealthFailures += 1
                 let failures = self.consecutiveEnhancedModeHealthFailures
+                self.enhancedModeRuntimeHealthSummary =
+                    "control-plane failed \(failures)/" +
+                    "\(Self.enhancedModeHealthFailureThreshold): \(reason)"
                 guard failures >= Self.enhancedModeHealthFailureThreshold else {
                     Logger.log(
                         "Enhanced Mode runtime health failed: \(reason) " +
@@ -1344,11 +1412,367 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     "Enhanced Mode runtime is unhealthy: \(reason); rebuilding core",
                     level: .error
                 )
-                self.restartEnhancedModeAfterWake(
-                    attemptsLeft: Self.wakeEnhancedModeRestartMaxAttempts
+                self.captureAndRestartEnhancedMode(
+                    reason: "control plane unhealthy after " +
+                        "\(Self.enhancedModeHealthFailureThreshold) checks: \(reason)"
                 )
             }
         }
+    }
+
+    private func checkEnhancedModeDataPlaneIfDue() {
+        let now = Date()
+        guard now.timeIntervalSince(lastEnhancedModeDataPlaneProbeAt) >=
+            Self.enhancedModeDataPlaneProbeInterval,
+            !isSpeedTesting,
+            !isConfigUpdating,
+            NetworkChangeNotifier.getPrimaryInterface() != nil else {
+            isEnhancedModeHealthCheckInFlight = false
+            return
+        }
+
+        lastEnhancedModeDataPlaneProbeAt = now
+        probeEnhancedModeDataPlane { [weak self] result in
+            guard let self = self else { return }
+            self.isEnhancedModeHealthCheckInFlight = false
+
+            guard Settings.enhancedMode,
+                  ConfigManager.shared.isEnhancedModeActive,
+                  self.enhancedModeMenuItem.isEnabled,
+                  !self.isWakeEnhancedModeRestarting,
+                  !self.isEnhancedModeRuntimeRecoveryPending else {
+                self.consecutiveEnhancedModeDataPlaneFailures = 0
+                return
+            }
+
+            self.handleEnhancedModeDataPlaneHealth(result)
+        }
+    }
+
+    private func probeEnhancedModeDataPlane(
+        completion: @escaping (EnhancedModeDataPlaneHealth) -> Void
+    ) {
+        probeEnhancedModeDataPlane(
+            context: EnhancedModeDataPlaneProbeContext(
+                urls: Self.enhancedModeDataPlaneProbeURLs,
+                index: 0,
+                coreFailureReasons: [],
+                directFailureReasons: []
+            )
+        ) { [weak self] outboundHealth in
+            guard let self = self else { return }
+            guard case let .healthy(delay) = outboundHealth else {
+                completion(outboundHealth)
+                return
+            }
+            self.probeCoreDNS { healthy, reason in
+                completion(
+                    healthy
+                        ? .healthy(delay: delay)
+                        : .coreUnavailable(reason)
+                )
+            }
+        }
+    }
+
+    private func probeEnhancedModeDataPlane(
+        context: EnhancedModeDataPlaneProbeContext,
+        completion: @escaping (EnhancedModeDataPlaneHealth) -> Void
+    ) {
+        guard context.index < context.urls.count else {
+            completion(.networkUnavailable(
+                coreReason: context.coreFailureReasons.joined(separator: "; "),
+                directReason: context.directFailureReasons.joined(separator: "; ")
+            ))
+            return
+        }
+
+        let probeURL = context.urls[context.index]
+        probeCoreDirectDataPlane(url: probeURL) { [weak self] delay, coreReason in
+            guard let self = self else { return }
+            if let delay {
+                completion(.healthy(delay: delay))
+                return
+            }
+
+            self.probeSystemDirectBaseline(url: probeURL) {
+                directReachable, directReason in
+                if directReachable {
+                    completion(.coreUnavailable(
+                        "endpoint \(context.index + 1): \(coreReason)"
+                    ))
+                } else {
+                    var nextContext = context
+                    nextContext.coreFailureReasons.append(
+                        "endpoint \(context.index + 1): \(coreReason)"
+                    )
+                    nextContext.directFailureReasons.append(
+                        "endpoint \(context.index + 1): \(directReason)"
+                    )
+                    nextContext.index += 1
+                    self.probeEnhancedModeDataPlane(
+                        context: nextContext,
+                        completion: completion
+                    )
+                }
+            }
+        }
+    }
+
+    private func probeCoreDirectDataPlane(
+        url probeURL: String,
+        completion: @escaping (_ delay: Int?, _ reason: String) -> Void
+    ) {
+        guard var components = URLComponents(
+            string: ConfigManager.apiUrl.appending("/proxies/DIRECT/delay")
+        ) else {
+            completion(nil, "invalid DIRECT probe URL")
+            return
+        }
+        components.queryItems = [
+            URLQueryItem(
+                name: "timeout",
+                value: "\(Self.enhancedModeDataPlaneProbeTimeoutMilliseconds)"
+            ),
+            URLQueryItem(name: "url", value: probeURL)
+        ]
+        guard let url = components.url else {
+            completion(nil, "invalid DIRECT probe query")
+            return
+        }
+
+        var request = URLRequest(
+            url: url,
+            cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
+            timeoutInterval: Self.enhancedModeDataPlaneProbeRequestTimeout
+        )
+        request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
+        for header in ApiRequest.authHeader() {
+            request.setValue(header.value, forHTTPHeaderField: header.name)
+        }
+
+        enhancedModeHealthURLSession.dataTask(with: request) { data, response, error in
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            let delay: Int? = {
+                guard (200 ..< 300).contains(statusCode),
+                      let data,
+                      let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let value = root["delay"] as? NSNumber,
+                      value.intValue > 0 else {
+                    return nil
+                }
+                return value.intValue
+            }()
+            let reason: String
+            if delay != nil {
+                reason = ""
+            } else if let error {
+                reason = "DIRECT probe error=\(error.localizedDescription)"
+            } else {
+                reason = "DIRECT probe status=\(statusCode) returned no delay"
+            }
+            DispatchQueue.main.async {
+                completion(delay, reason)
+            }
+        }.resume()
+    }
+
+    private func probeSystemDirectBaseline(
+        url probeURL: String,
+        completion: @escaping (_ reachable: Bool, _ reason: String) -> Void
+    ) {
+        guard let url = URL(string: probeURL) else {
+            completion(false, "invalid direct baseline URL")
+            return
+        }
+        var request = URLRequest(
+            url: url,
+            cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
+            timeoutInterval: Self.enhancedModeDataPlaneProbeRequestTimeout
+        )
+        request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
+
+        enhancedModeHealthURLSession.dataTask(with: request) { _, response, error in
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            let reachable = response is HTTPURLResponse
+            let reason: String
+            if reachable {
+                reason = "status=\(statusCode)"
+            } else {
+                reason = error?.localizedDescription ?? "no HTTP response"
+            }
+            DispatchQueue.main.async {
+                completion(reachable, reason)
+            }
+        }.resume()
+    }
+
+    private func probeCoreDNS(
+        completion: @escaping (_ healthy: Bool, _ reason: String) -> Void
+    ) {
+        guard var components = URLComponents(
+            string: ConfigManager.apiUrl.appending("/dns/query")
+        ) else {
+            completion(false, "invalid DNS probe URL")
+            return
+        }
+        components.queryItems = [
+            URLQueryItem(name: "name", value: Self.enhancedModeDNSProbeName),
+            URLQueryItem(name: "type", value: "A")
+        ]
+        guard let url = components.url else {
+            completion(false, "invalid DNS probe query")
+            return
+        }
+
+        var request = URLRequest(
+            url: url,
+            cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
+            timeoutInterval: Self.enhancedModeDataPlaneProbeRequestTimeout
+        )
+        request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
+        for header in ApiRequest.authHeader() {
+            request.setValue(header.value, forHTTPHeaderField: header.name)
+        }
+
+        enhancedModeHealthURLSession.dataTask(with: request) { data, response, error in
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            let dnsHealthy: Bool = {
+                guard (200 ..< 300).contains(statusCode),
+                      let data,
+                      let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      (root["Status"] as? NSNumber)?.intValue == 0,
+                      let answers = root["Answer"] as? [Any],
+                      !answers.isEmpty else {
+                    return false
+                }
+                return true
+            }()
+            let reason: String
+            if dnsHealthy {
+                reason = ""
+            } else if let error {
+                reason = "core DNS probe error=\(error.localizedDescription)"
+            } else {
+                reason = "core DNS probe status=\(statusCode) returned no answer"
+            }
+            DispatchQueue.main.async {
+                completion(dnsHealthy, reason)
+            }
+        }.resume()
+    }
+
+    private func handleEnhancedModeDataPlaneHealth(_ health: EnhancedModeDataPlaneHealth) {
+        switch health {
+        case let .healthy(delay):
+            if consecutiveEnhancedModeDataPlaneFailures > 0 {
+                Logger.log(
+                    "Enhanced Mode data plane recovered (DIRECT \(delay) ms)"
+                )
+            }
+            consecutiveEnhancedModeDataPlaneFailures = 0
+            enhancedModeRuntimeHealthSummary = "healthy (DIRECT \(delay) ms)"
+
+        case let .networkUnavailable(coreReason, directReason):
+            if consecutiveEnhancedModeDataPlaneFailures > 0 {
+                Logger.log(
+                    "Enhanced Mode data-plane result is inconclusive because the " +
+                        "system direct baseline also failed; clearing failure streak",
+                    level: .warning
+                )
+            }
+            consecutiveEnhancedModeDataPlaneFailures = 0
+            enhancedModeRuntimeHealthSummary =
+                "inconclusive (system direct baseline unavailable)"
+            Logger.log(
+                "Enhanced Mode data-plane probe inconclusive: core=\(coreReason); " +
+                    "system-direct=\(directReason)",
+                level: .warning
+            )
+
+        case let .coreUnavailable(reason):
+            consecutiveEnhancedModeDataPlaneFailures += 1
+            let failures = consecutiveEnhancedModeDataPlaneFailures
+            enhancedModeRuntimeHealthSummary =
+                "failed \(failures)/\(Self.enhancedModeDataPlaneFailureThreshold) " +
+                "(system direct baseline healthy)"
+
+            guard failures >= Self.enhancedModeDataPlaneFailureThreshold else {
+                Logger.log(
+                    "Enhanced Mode data-plane probe failed while system direct is " +
+                        "reachable: \(reason) " +
+                        "(\(failures)/\(Self.enhancedModeDataPlaneFailureThreshold))",
+                    level: .warning
+                )
+                return
+            }
+
+            consecutiveEnhancedModeDataPlaneFailures = 0
+            let now = Date()
+            guard now.timeIntervalSince(lastEnhancedModeDataPlaneRecoveryTime) >=
+                Self.enhancedModeDataPlaneRecoveryCooldown else {
+                enhancedModeRuntimeHealthSummary =
+                    "failure threshold reached; recovery cooldown active"
+                Logger.log(
+                    "Enhanced Mode data plane remains unhealthy, but automatic " +
+                        "recovery is in cooldown",
+                    level: .warning
+                )
+                return
+            }
+
+            lastEnhancedModeDataPlaneRecoveryTime = now
+            enhancedModeRuntimeHealthSummary =
+                "automatic recovery triggered after confirmed data-plane failures"
+            let diagnosticReason =
+                "runtime data plane failed \(Self.enhancedModeDataPlaneFailureThreshold) " +
+                "times while system direct remained reachable: \(reason)"
+            captureAndRestartEnhancedMode(reason: diagnosticReason)
+        }
+    }
+
+    private func captureAndRestartEnhancedMode(reason: String) {
+        guard Settings.enhancedMode || ConfigManager.shared.isEnhancedModeActive,
+              enhancedModeMenuItem.isEnabled,
+              !isWakeEnhancedModeRestarting,
+              !isEnhancedModeRuntimeRecoveryPending else {
+            return
+        }
+
+        isEnhancedModeRuntimeRecoveryPending = true
+        enhancedModeRuntimeHealthSummary =
+            "automatic recovery pending after confirmed runtime failure"
+        logEnhancedModeRuntimeDiagnosticSnapshot(reason: reason)
+        captureExternalCoreDiagnostic(reason: reason) { [weak self] in
+            guard let self = self else { return }
+            self.isEnhancedModeRuntimeRecoveryPending = false
+            guard Settings.enhancedMode || ConfigManager.shared.isEnhancedModeActive,
+                  self.enhancedModeMenuItem.isEnabled,
+                  !self.isWakeEnhancedModeRestarting else {
+                return
+            }
+            Logger.log(
+                "Enhanced Mode runtime is unhealthy after confirmed checks; " +
+                    "rebuilding core",
+                level: .error
+            )
+            self.restartEnhancedModeAfterWake(
+                attemptsLeft: Self.wakeEnhancedModeRestartMaxAttempts
+            )
+        }
+    }
+
+    private func logEnhancedModeRuntimeDiagnosticSnapshot(reason: String) {
+        let config = ConfigManager.shared.currentConfig
+        Logger.log(
+            "Enhanced Mode runtime diagnostic: reason=\(reason); " +
+                "primaryInterface=\(NetworkChangeNotifier.getPrimaryInterface() ?? "none"); " +
+                "systemProxyMatches=\(NetworkChangeNotifier.isCurrentSystemSetToClash()); " +
+                "httpPort=\(config?.usedHttpPort ?? 0); " +
+                "apiPort=\(ConfigManager.shared.apiPort); " +
+                "tun=\(tunInterfaceSummaryForLog())",
+            level: .error
+        )
     }
 
     private func recoverFromCoreLogFailure(_ reason: CoreLogRecoveryReason) {
@@ -1357,7 +1781,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             guard Settings.enhancedMode,
                   ConfigManager.shared.isEnhancedModeActive,
                   self.enhancedModeMenuItem.isEnabled,
-                  !self.isWakeEnhancedModeRestarting else {
+                  !self.isWakeEnhancedModeRestarting,
+                  !self.isEnhancedModeRuntimeRecoveryPending else {
                 return
             }
             let now = Date()
@@ -1374,8 +1799,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 message = "Detected a TUN outbound-interface error storm; rebuilding Enhanced Mode"
             }
             Logger.log(message, level: .error)
-            self.restartEnhancedModeAfterWake(
-                attemptsLeft: Self.wakeEnhancedModeRestartMaxAttempts
+            self.captureAndRestartEnhancedMode(
+                reason: "fatal core log signal: \(message)"
             )
         }
 
@@ -1458,7 +1883,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func restoreCoreAfterWake() {
         if Settings.enhancedMode || ConfigManager.shared.isEnhancedModeActive {
             Logger.log("Wake recovery: stopping and rebuilding Enhanced Mode")
-            restartEnhancedModeAfterWake(attemptsLeft: Self.wakeEnhancedModeRestartMaxAttempts)
+            captureAndRestartEnhancedMode(
+                reason: "wake/network recovery exhausted after core health failures"
+            )
             return
         }
 
@@ -1543,8 +1970,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func restartEnhancedModeAfterWake(attemptsLeft: Int) {
         if attemptsLeft == Self.wakeEnhancedModeRestartMaxAttempts {
-            guard !isWakeEnhancedModeRestarting else { return }
+            guard !isWakeEnhancedModeRestarting,
+                  !isEnhancedModeRuntimeRecoveryPending else { return }
             isWakeEnhancedModeRestarting = true
+            didRestartHelperDuringEnhancedLaunch = false
             cancelActiveSpeedTestForCoreRecovery()
         }
 
@@ -2015,6 +2444,7 @@ extension AppDelegate {
         // re-picks the controller port (stable 19090, or a fresh free port if it
         // is occupied by a stale core). This absorbs transient port races and
         // leftover mihomo_core processes that would otherwise fail the launch.
+        didRestartHelperDuringEnhancedLaunch = false
         attemptEnableEnhancedMode(attemptsLeft: 1, alreadySuspended: false, completion: completion)
     }
 
@@ -2174,6 +2604,7 @@ extension AppDelegate {
                     return
                 }
 
+                self.logExternalCoreLaunchStatus(using: helper)
                 ConfigManager.shared.apiPort = port
                 ConfigManager.shared.apiSecret = secret
                 ConfigManager.shared.isEnhancedModeActive = true
@@ -2195,8 +2626,9 @@ extension AppDelegate {
                         Logger.log("External core not ready, regenerating config and retrying (\(attemptsLeft) left)", level: .warning)
                         ConfigManager.shared.isEnhancedModeActive = false
                         self.refreshStatusItemViewStatus()
-                        helper.stopMihomoCore { _ in
-                            DispatchQueue.main.async {
+                        self.prepareHelperForEnhancedModeRetry(helper: helper) {
+                            DispatchQueue.main.async { [weak self] in
+                                guard let self = self else { return }
                                 self.attemptEnableEnhancedMode(attemptsLeft: attemptsLeft - 1, alreadySuspended: true, completion: completion)
                             }
                         }
@@ -2216,6 +2648,167 @@ extension AppDelegate {
                     }
                 }
             }
+        }
+    }
+
+    private func logExternalCoreLaunchStatus(using helper: ProxyConfigRemoteProcessProtocol) {
+        let invocation: Void? = helper.getMihomoCoreStatus? { optionalStatus in
+            let status = optionalStatus ?? [:]
+            let launchID = status["launchID"] as? String ?? "unknown"
+            let pid = (status["pid"] as? NSNumber)?.intValue ?? 0
+            let logPath = status["logPath"] as? String ?? "unknown"
+            let logBytes = (status["logBytes"] as? NSNumber)?.uint64Value ?? 0
+            Logger.log(
+                "External core launched: id=\(launchID) pid=\(pid) " +
+                    "log=\(logPath) initialBytes=\(logBytes)"
+            )
+        }
+        if invocation == nil {
+            Logger.log(
+                "Installed helper does not expose external-core launch metadata",
+                level: .warning
+            )
+        }
+    }
+
+    private func captureExternalCoreDiagnostic(
+        reason: String,
+        completion: @escaping () -> Void
+    ) {
+        guard let helper = PrivilegedHelperManager.shared.helper() else {
+            Logger.log(
+                "Unable to capture external-core diagnostic: helper unavailable",
+                level: .warning
+            )
+            completion()
+            return
+        }
+
+        logExternalCoreLaunchStatus(using: helper)
+        var didFinish = false
+        let finish: () -> Void = {
+            guard !didFinish else { return }
+            didFinish = true
+            completion()
+        }
+        let invocation: Void? = helper.captureMihomoCoreDiagnostic?(withReason: reason) { result in
+            DispatchQueue.main.async {
+                if let result, result.hasPrefix("error:") {
+                    Logger.log(
+                        "External-core diagnostic failed: \(result)",
+                        level: .warning
+                    )
+                } else {
+                    Logger.log(
+                        "External-core diagnostic saved: \(result ?? "unknown path")",
+                        level: .error
+                    )
+                }
+                finish()
+            }
+        }
+        if invocation == nil {
+            Logger.log(
+                "Installed helper does not support external-core process sampling",
+                level: .warning
+            )
+            finish()
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.enhancedModeDiagnosticTimeout) {
+            guard !didFinish else { return }
+            Logger.log(
+                "External-core diagnostic timed out; continuing recovery",
+                level: .warning
+            )
+            finish()
+        }
+    }
+
+    private func prepareHelperForEnhancedModeRetry(
+        helper: ProxyConfigRemoteProcessProtocol,
+        completion: @escaping () -> Void
+    ) {
+        guard !didRestartHelperDuringEnhancedLaunch else {
+            stopExternalCoreForRetry(helper: helper, completion: completion)
+            return
+        }
+
+        didRestartHelperDuringEnhancedLaunch = true
+        var didFinishRequest = false
+        let finishRequest: (String?) -> Void = { error in
+            guard !didFinishRequest else { return }
+            didFinishRequest = true
+            if let error {
+                Logger.log(
+                    "Helper host restart reported an error: \(error)",
+                    level: .warning
+                )
+            } else {
+                Logger.log(
+                    "Restarted helper host before retrying the external core",
+                    level: .warning
+                )
+            }
+            PrivilegedHelperManager.shared.resetConnection()
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + Self.enhancedModeHelperRestartDelay,
+                execute: completion
+            )
+        }
+        let invocation: Void? = helper.restartMihomoCoreHost? { error in
+            DispatchQueue.main.async {
+                finishRequest(error)
+            }
+        }
+        if invocation == nil {
+            Logger.log(
+                "Installed helper does not support a host restart; stopping only",
+                level: .warning
+            )
+            stopExternalCoreForRetry(helper: helper, completion: completion)
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.enhancedModeHelperRequestTimeout) {
+            guard !didFinishRequest else { return }
+            Logger.log(
+                "Helper host restart request timed out; reconnecting before retry",
+                level: .warning
+            )
+            finishRequest("request timed out")
+        }
+    }
+
+    private func stopExternalCoreForRetry(
+        helper: ProxyConfigRemoteProcessProtocol,
+        completion: @escaping () -> Void
+    ) {
+        var didFinish = false
+        let finish: () -> Void = {
+            guard !didFinish else { return }
+            didFinish = true
+            completion()
+        }
+        helper.stopMihomoCore { error in
+            DispatchQueue.main.async {
+                if let error {
+                    Logger.log(
+                        "Failed stopping external core before retry: \(error)",
+                        level: .warning
+                    )
+                }
+                finish()
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.enhancedModeHelperRequestTimeout) {
+            guard !didFinish else { return }
+            Logger.log(
+                "Stopping external core timed out; continuing bounded retry",
+                level: .warning
+            )
+            finish()
         }
     }
 
@@ -2245,6 +2838,9 @@ extension AppDelegate {
                         Self.enhancedModeHealthGracePeriod
                     )
                     self.consecutiveEnhancedModeHealthFailures = 0
+                    self.consecutiveEnhancedModeDataPlaneFailures = 0
+                    self.enhancedModeRuntimeHealthSummary =
+                        "waiting for post-start data-plane health check"
                     ready(true)
                 } else if retriesLeft > 0 {
                     Logger.log("Waiting for external core listeners (\(retriesLeft) retries left)...", level: .debug)
@@ -2253,7 +2849,11 @@ extension AppDelegate {
                     }
                 } else {
                     Logger.log("External core listeners not ready after all retries", level: .error)
-                    ready(false)
+                    self.captureExternalCoreDiagnostic(
+                        reason: "API/listeners not ready on controller port \(port)"
+                    ) {
+                        ready(false)
+                    }
                 }
             }
         }.resume()

--- a/ClashFX/General/ApiRequest.swift
+++ b/ClashFX/General/ApiRequest.swift
@@ -116,7 +116,9 @@ class ApiRequest {
     private static let benchmarkRequestTimeoutMargin: TimeInterval = 5
     private static let benchmarkMinimumRequestTimeout: TimeInterval = 10
 
-    private var proxyRespCache: ClashProxyResp?
+    private var proxyRespCacheData: Data?
+    private var rulesCache: [ClashRule] = []
+    private var lastProxyCacheFallbackLogDate = Date.distantPast
 
     static let clashRequestQueue = DispatchQueue(label: "com.clashfx.clashRequestQueue")
 
@@ -354,11 +356,39 @@ class ApiRequest {
     }
 
     static func requestProxyGroupList(completeHandler: ((ClashProxyResp) -> Void)? = nil) {
-        req("/proxies").responseData {
-            res in
-            let proxies = ClashProxyResp(try? res.result.get())
-            ApiRequest.shared.proxyRespCache = proxies
-            completeHandler?(proxies)
+        req("/proxies").responseData { res in
+            let statusCode = res.response?.statusCode ?? -1
+            if case let .success(data) = res.result,
+               (200 ..< 300).contains(statusCode),
+               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               root["proxies"] is [String: Any] {
+                let proxies = ClashProxyResp(data)
+                ApiRequest.shared.proxyRespCacheData = data
+                completeHandler?(proxies)
+                return
+            }
+
+            if let cachedData = ApiRequest.shared.proxyRespCacheData {
+                let cached = ClashProxyResp(cachedData)
+                let now = Date()
+                if now.timeIntervalSince(ApiRequest.shared.lastProxyCacheFallbackLogDate) >= 15 {
+                    ApiRequest.shared.lastProxyCacheFallbackLogDate = now
+                    Logger.log(
+                        "Proxy API unavailable (status=\(statusCode)); " +
+                            "preserving the last valid menu snapshot with " +
+                            "\(cached.proxiesMap.count) entries",
+                        level: .warning
+                    )
+                }
+                completeHandler?(cached)
+                return
+            }
+
+            Logger.log(
+                "Proxy API unavailable (status=\(statusCode)) and no valid snapshot exists",
+                level: .warning
+            )
+            completeHandler?(ClashProxyResp(nil))
         }
     }
 
@@ -774,9 +804,24 @@ class ApiRequest {
 
     static func getRules(completeHandler: @escaping ([ClashRule]) -> Void) {
         req("/rules").responseData { res in
-            guard let data = try? res.result.get() else { return }
-            let rule = ClashRuleResponse.fromData(data)
-            completeHandler(rule.rules ?? [])
+            let statusCode = res.response?.statusCode ?? -1
+            if case let .success(data) = res.result,
+               (200 ..< 300).contains(statusCode),
+               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               root["rules"] is [Any] {
+                let rule = ClashRuleResponse.fromData(data)
+                let rules = rule.rules ?? []
+                ApiRequest.shared.rulesCache = rules
+                completeHandler(rules)
+                return
+            }
+
+            Logger.log(
+                "Rules API unavailable (status=\(statusCode)); preserving the last " +
+                    "valid snapshot with \(ApiRequest.shared.rulesCache.count) rules",
+                level: .warning
+            )
+            completeHandler(ApiRequest.shared.rulesCache)
         }
     }
 

--- a/ClashFX/General/Managers/LabSupport.swift
+++ b/ClashFX/General/Managers/LabSupport.swift
@@ -41,6 +41,7 @@ enum LabSupport {
         lines.append("- System Proxy Matches ClashFX: \(NetworkChangeNotifier.isCurrentSystemSetToClash())")
         lines.append("- DNS Servers: \(NetworkChangeNotifier.getCurrentDns().joined(separator: ", "))")
         lines.append("- TUN Interfaces: \(tunInterfaceSummary())")
+        lines.append("- Enhanced Runtime Health: \(AppDelegate.shared.enhancedModeRuntimeHealthSummary)")
         lines.append("")
         lines.append("### Recent log (last 50 lines, sensitive data redacted)")
         lines.append("```")

--- a/ClashFX/General/Managers/MenuItemFactory.swift
+++ b/ClashFX/General/Managers/MenuItemFactory.swift
@@ -20,13 +20,20 @@ class MenuItemFactory {
     static func refreshExistingMenuItems() {
         ApiRequest.getMergedProxyData {
             info in
-            if info?.proxiesMap.keys != cachedProxyData?.proxiesMap.keys {
+            guard let info, !info.proxiesMap.isEmpty else {
+                Logger.log(
+                    "Skipped proxy-menu refresh because no valid proxy snapshot is available",
+                    level: .warning
+                )
+                return
+            }
+            if info.proxiesMap.keys != cachedProxyData?.proxiesMap.keys {
                 cachedProxyData = info
                 refreshMenuItems(mergedData: info)
                 return
             }
 
-            for proxy in info?.proxies ?? [] {
+            for proxy in info.proxies {
                 NotificationCenter.default.post(name: .proxyUpdate(for: proxy.name), object: proxy, userInfo: nil)
             }
         }
@@ -35,6 +42,13 @@ class MenuItemFactory {
     static func recreateProxyMenuItems() {
         ApiRequest.getMergedProxyData {
             proxyInfo in
+            guard let proxyInfo, !proxyInfo.proxiesMap.isEmpty else {
+                Logger.log(
+                    "Kept existing proxy menu because the refreshed snapshot is empty",
+                    level: .warning
+                )
+                return
+            }
             cachedProxyData = proxyInfo
             refreshMenuItems(mergedData: proxyInfo)
         }

--- a/ClashFX/Support Files/en.lproj/Localizable.strings
+++ b/ClashFX/Support Files/en.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "Failed to Stop Enhanced Mode" = "Failed to Stop Enhanced Mode";
 "TUN Route Exclude contains invalid entries:\n%@\n\nSeparate entries with commas or new lines, or reset the list." = "TUN Route Exclude contains invalid entries:\n%@\n\nSeparate entries with commas or new lines, or reset the list.";
 "Open Settings" = "Open Settings";
+"Core temporarily unavailable; showing the last valid rules snapshot" = "Core temporarily unavailable; showing the last valid rules snapshot";

--- a/ClashFX/Support Files/ja.lproj/Localizable.strings
+++ b/ClashFX/Support Files/ja.lproj/Localizable.strings
@@ -593,3 +593,4 @@
 "Failed to Stop Enhanced Mode" = "拡張モードを停止できませんでした";
 "TUN Route Exclude contains invalid entries:\n%@\n\nSeparate entries with commas or new lines, or reset the list." = "TUN ルート除外に無効な項目があります：\n%@\n\n項目をカンマまたは改行で区切るか、リストをリセットしてください。";
 "Open Settings" = "設定を開く";
+"Core temporarily unavailable; showing the last valid rules snapshot" = "コアは一時的に利用できません。最後の有効なルールのスナップショットを表示しています";

--- a/ClashFX/Support Files/ru.lproj/Localizable.strings
+++ b/ClashFX/Support Files/ru.lproj/Localizable.strings
@@ -593,3 +593,4 @@
 "Failed to Stop Enhanced Mode" = "Не удалось остановить расширенный режим";
 "TUN Route Exclude contains invalid entries:\n%@\n\nSeparate entries with commas or new lines, or reset the list." = "Список исключений маршрутов TUN содержит недопустимые элементы:\n%@\n\nРазделите элементы запятыми или переносами строк либо сбросьте список.";
 "Open Settings" = "Открыть настройки";
+"Core temporarily unavailable; showing the last valid rules snapshot" = "Ядро временно недоступно; показан последний действительный снимок правил";

--- a/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
@@ -633,3 +633,4 @@
 "Failed to Stop Enhanced Mode" = "增强模式停止失败";
 "TUN Route Exclude contains invalid entries:\n%@\n\nSeparate entries with commas or new lines, or reset the list." = "TUN 路由排除中包含无效条目：\n%@\n\n请使用逗号或换行分隔条目，或者重置该列表。";
 "Open Settings" = "打开设置";
+"Core temporarily unavailable; showing the last valid rules snapshot" = "核心暂时不可用，正在显示上一次有效的规则快照";

--- a/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hant.lproj/Localizable.strings
@@ -593,3 +593,4 @@
 "Failed to Stop Enhanced Mode" = "增強模式停止失敗";
 "TUN Route Exclude contains invalid entries:\n%@\n\nSeparate entries with commas or new lines, or reset the list." = "TUN 路由排除中包含無效項目：\n%@\n\n請使用逗號或換行分隔項目，或者重設此列表。";
 "Open Settings" = "開啟設定";
+"Core temporarily unavailable; showing the last valid rules snapshot" = "核心暫時無法使用，正在顯示上次有效的規則快照";

--- a/ClashFX/ViewControllers/ClashWebViewContoller.swift
+++ b/ClashFX/ViewControllers/ClashWebViewContoller.swift
@@ -176,6 +176,108 @@ class ClashWebViewContoller: NSViewController {
         """
     }
 
+    private static func dashboardRulesSnapshotJS(port: String, staleMessage: String) -> String {
+        let backendURL = "http://127.0.0.1:\(port)"
+        let escapedBackendURL = backendURL
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+        let escapedStaleMessage = staleMessage
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+            .replacingOccurrences(of: "\n", with: "\\n")
+        return """
+        (function() {
+          var BACKEND_ORIGIN = '\(escapedBackendURL)';
+          var STALE_MESSAGE = '\(escapedStaleMessage)';
+          var BANNER_ID = 'clashfx-stale-rules-banner';
+          var rulesSnapshot = null;
+          var originalFetch = window.fetch;
+
+          function isRulesRequest(input, init) {
+            var method = ((init && init.method) ||
+              (typeof input !== 'string' && input.method) || 'GET').toUpperCase();
+            if (method !== 'GET') return false;
+            var rawURL = (typeof input === 'string') ? input : (input.url || '');
+            try {
+              var url = new URL(rawURL, window.location.href);
+              return url.origin === BACKEND_ORIGIN && url.pathname === '/rules';
+            } catch (_) {
+              return false;
+            }
+          }
+
+          function showStaleBanner() {
+            if (document.getElementById(BANNER_ID)) return;
+            var banner = document.createElement('div');
+            banner.id = BANNER_ID;
+            banner.textContent = STALE_MESSAGE;
+            banner.style.position = 'fixed';
+            banner.style.top = '10px';
+            banner.style.left = '50%';
+            banner.style.transform = 'translateX(-50%)';
+            banner.style.zIndex = '2147483647';
+            banner.style.padding = '7px 12px';
+            banner.style.borderRadius = '8px';
+            banner.style.background = 'rgba(154, 87, 0, 0.94)';
+            banner.style.color = '#fff';
+            banner.style.font = '12px -apple-system, BlinkMacSystemFont, sans-serif';
+            banner.style.boxShadow = '0 2px 8px rgba(0, 0, 0, 0.22)';
+            banner.style.pointerEvents = 'none';
+            (document.body || document.documentElement).appendChild(banner);
+          }
+
+          function hideStaleBanner() {
+            var banner = document.getElementById(BANNER_ID);
+            if (banner) banner.remove();
+          }
+
+          function rememberRules(response) {
+            response.clone().text().then(function(text) {
+              try {
+                var payload = JSON.parse(text);
+                if (!Array.isArray(payload.rules)) return;
+                rulesSnapshot = text;
+                hideStaleBanner();
+              } catch (_) {}
+            });
+          }
+
+          function staleRulesResponse() {
+            showStaleBanner();
+            console.warn('[ClashFX] Core unavailable; serving the last valid rules snapshot');
+            return new Response(rulesSnapshot, {
+              status: 200,
+              headers: {
+                'Content-Type': 'application/json',
+                'X-ClashFX-Stale-Snapshot': 'rules'
+              }
+            });
+          }
+
+          window.fetch = function(input, init) {
+            if (!isRulesRequest(input, init)) {
+              return originalFetch.apply(this, arguments);
+            }
+            var receiver = this;
+            var args = arguments;
+            return originalFetch.apply(receiver, args).then(function(response) {
+              if (response && response.ok) {
+                rememberRules(response);
+                return response;
+              }
+              if (rulesSnapshot && response && response.status >= 500) {
+                return staleRulesResponse();
+              }
+              return response;
+            }).catch(function(error) {
+              if (rulesSnapshot) return staleRulesResponse();
+              throw error;
+            });
+          };
+        })();
+        """
+    }
+
     private static func metaCubeXDSetupURL(port: String, secret: String) -> URL? {
         var allowed = CharacterSet.urlQueryAllowed
         allowed.remove(charactersIn: "&=+")
@@ -206,6 +308,15 @@ class ClashWebViewContoller: NSViewController {
         let secret = ConfigManager.shared.overrideSecret ?? ConfigManager.shared.apiSecret
         let metaCubeXDConfigScript = WKUserScript(source: Self.metaCubeXDConfigJS(port: port, secret: secret), injectionTime: .atDocumentStart, forMainFrameOnly: true)
         let guardScript = WKUserScript(source: Self.apiGuardJS, injectionTime: .atDocumentStart, forMainFrameOnly: true)
+        let staleRulesMessage = NSLocalizedString(
+            "Core temporarily unavailable; showing the last valid rules snapshot",
+            comment: ""
+        )
+        let rulesSnapshotScript = WKUserScript(
+            source: Self.dashboardRulesSnapshotJS(port: port, staleMessage: staleRulesMessage),
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
         let managedMessage = NSLocalizedString(
             "Dashboard and core updates are managed by ClashFX",
             comment: ""
@@ -217,6 +328,7 @@ class ClashWebViewContoller: NSViewController {
         )
         webview.configuration.userContentController.addUserScript(metaCubeXDConfigScript)
         webview.configuration.userContentController.addUserScript(guardScript)
+        webview.configuration.userContentController.addUserScript(rulesSnapshotScript)
         webview.configuration.userContentController.addUserScript(hideScript)
 
         bridge = JsBridgeUtil.initJSbridge(webview: webview, delegate: self)

--- a/ProxyConfigHelper/Helper-Info.plist
+++ b/ProxyConfigHelper/Helper-Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleName</key>
 	<string>com.clashfx.app.Helper</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2</string>
+	<string>1.3</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>anchor apple generic and identifier &quot;com.clashfx.app&quot; and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MEWHFZ92DY)</string>

--- a/ProxyConfigHelper/ProxyConfigHelper.m
+++ b/ProxyConfigHelper/ProxyConfigHelper.m
@@ -9,6 +9,7 @@
 #import "ProxyConfigHelper.h"
 #import <AppKit/AppKit.h>
 #import <Security/Security.h>
+#import <fcntl.h>
 #import <libproc.h>
 #import <signal.h>
 #import <string.h>
@@ -28,6 +29,12 @@ ProxyConfigRemoteProcessProtocol
 @property (nonatomic, strong) NSTimer *idleExitTimer;
 @property (nonatomic, assign) BOOL shouldQuit;
 @property (nonatomic, strong) NSTask *mihomoTask;
+@property (nonatomic, copy) NSString *mihomoLaunchID;
+@property (nonatomic, copy) NSString *mihomoLogPath;
+@property (nonatomic, copy) NSString *mihomoHomeDir;
+@property (nonatomic, strong) NSDate *mihomoLaunchDate;
+@property (nonatomic, assign) pid_t mihomoProcessID;
+@property (nonatomic, copy) NSString *mihomoLastTerminationSummary;
 
 - (void)terminateMihomoTask:(NSTask *)task completion:(dispatch_block_t)completion;
 - (void)launchMihomoCoreWithBinaryPath:(NSString *)binaryPath
@@ -41,6 +48,7 @@ ProxyConfigRemoteProcessProtocol
 
 static const NSTimeInterval kMihomoGracefulStopTimeout = 2.0;
 static const unsigned long long kMihomoCoreLogMaximumBytes = 4 * 1024 * 1024;
+static const NSUInteger kMihomoDiagnosticFileLimit = 24;
 static const NSTimeInterval kDNSCacheCommandTimeout = 2.0;
 // Give a newly launched ClashFX instance enough time to attach before an
 // invalidated connection from the previous instance lets the helper exit.
@@ -51,6 +59,24 @@ static const NSTimeInterval kIdleExitGracePeriod = 10.0;
 // app repeatedly reinstall an already healthy helper.
 static const NSTimeInterval kInitialConnectionGracePeriod = 60.0;
 
+static void AppendLineToFile(NSString *path, NSString *line) {
+    if (path.length == 0 || line.length == 0) {
+        return;
+    }
+
+    int fd = open(path.fileSystemRepresentation, O_WRONLY | O_APPEND);
+    if (fd < 0) {
+        return;
+    }
+
+    NSString *terminatedLine = [line hasSuffix:@"\n"] ? line : [line stringByAppendingString:@"\n"];
+    NSData *data = [terminatedLine dataUsingEncoding:NSUTF8StringEncoding];
+    if (data.length > 0) {
+        (void)write(fd, data.bytes, data.length);
+    }
+    close(fd);
+}
+
 static BOOL RunTaskWithTimeout(NSString *executablePath,
                                NSArray<NSString *> *arguments,
                                NSTimeInterval timeout) {
@@ -60,7 +86,7 @@ static BOOL RunTaskWithTimeout(NSString *executablePath,
 
     NSError *launchError = nil;
     if (![task launchAndReturnError:&launchError]) {
-        NSLog(@"DNS cache command failed to launch (%@): %@",
+        NSLog(@"Command failed to launch (%@): %@",
               executablePath.lastPathComponent,
               launchError.localizedDescription);
         return NO;
@@ -74,7 +100,7 @@ static BOOL RunTaskWithTimeout(NSString *executablePath,
         return task.terminationStatus == 0;
     }
 
-    NSLog(@"DNS cache command timed out after %.1fs: %@",
+    NSLog(@"Command timed out after %.1fs: %@",
           timeout,
           executablePath.lastPathComponent);
     [task terminate];
@@ -98,6 +124,81 @@ static BOOL RunTaskWithTimeout(NSString *executablePath,
         self.listener.delegate = self;
     }
     return self;
+}
+
+- (NSString *)newMihomoLaunchID {
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+    formatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
+    formatter.dateFormat = @"yyyyMMdd-HHmmss-SSS";
+    NSString *timestamp = [formatter stringFromDate:[NSDate date]];
+    NSString *suffix = [[[NSUUID UUID] UUIDString] substringToIndex:8].lowercaseString;
+    return [NSString stringWithFormat:@"%@-%@", timestamp, suffix];
+}
+
+- (void)pruneMihomoDiagnosticDirectory:(NSString *)directory
+                           keepingPath:(NSString *)currentPath {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSArray<NSURL *> *files = [fileManager contentsOfDirectoryAtURL:[NSURL fileURLWithPath:directory]
+                                          includingPropertiesForKeys:@[NSURLContentModificationDateKey]
+                                                             options:NSDirectoryEnumerationSkipsHiddenFiles
+                                                               error:nil];
+    files = [files filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSURL *url, NSDictionary *_) {
+        return [url.pathExtension isEqualToString:@"log"] ||
+            [url.lastPathComponent hasSuffix:@".sample.txt"];
+    }]];
+    files = [files sortedArrayUsingComparator:^NSComparisonResult(NSURL *lhs, NSURL *rhs) {
+        NSDate *leftDate = nil;
+        NSDate *rightDate = nil;
+        [lhs getResourceValue:&leftDate forKey:NSURLContentModificationDateKey error:nil];
+        [rhs getResourceValue:&rightDate forKey:NSURLContentModificationDateKey error:nil];
+        return [(rightDate ?: NSDate.distantPast) compare:(leftDate ?: NSDate.distantPast)];
+    }];
+
+    NSUInteger kept = 0;
+    for (NSURL *file in files) {
+        if ([file.path isEqualToString:currentPath] || kept < kMihomoDiagnosticFileLimit) {
+            kept += 1;
+            continue;
+        }
+        [fileManager removeItemAtURL:file error:nil];
+    }
+}
+
+- (NSString *)prepareMihomoLogForHomeDir:(NSString *)homeDir
+                                launchID:(NSString *)launchID {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *logDirectory = [homeDir stringByAppendingPathComponent:@".mihomo_core_logs"];
+    NSError *directoryError = nil;
+    if (![fileManager createDirectoryAtPath:logDirectory
+                withIntermediateDirectories:YES
+                                 attributes:@{NSFilePosixPermissions: @(0755)}
+                                      error:&directoryError]) {
+        NSLog(@"[mihomo_core] Failed creating diagnostic directory: %@",
+              directoryError.localizedDescription);
+    }
+
+    NSString *uniqueLogPath = [logDirectory
+        stringByAppendingPathComponent:[NSString stringWithFormat:@"mihomo-%@.log", launchID]];
+    [fileManager createFileAtPath:uniqueLogPath
+                        contents:[NSData data]
+                      attributes:@{NSFilePosixPermissions: @(0644)}];
+
+    NSString *stableLogPath = [homeDir stringByAppendingPathComponent:@".mihomo_core.log"];
+    [fileManager removeItemAtPath:stableLogPath error:nil];
+    NSError *linkError = nil;
+    if (![fileManager linkItemAtPath:uniqueLogPath toPath:stableLogPath error:&linkError]) {
+        NSLog(@"[mihomo_core] Failed linking active log to diagnostic log: %@",
+              linkError.localizedDescription);
+        [fileManager removeItemAtPath:uniqueLogPath error:nil];
+        [fileManager createFileAtPath:stableLogPath
+                            contents:[NSData data]
+                          attributes:@{NSFilePosixPermissions: @(0644)}];
+        uniqueLogPath = stableLogPath;
+    }
+
+    [self pruneMihomoDiagnosticDirectory:logDirectory keepingPath:uniqueLogPath];
+    return uniqueLogPath;
 }
 
 - (NSArray<NSNumber *> *)mihomoProcessIDsMatchingBinaryPath:(NSString *)binaryPath
@@ -428,6 +529,117 @@ static BOOL RunTaskWithTimeout(NSString *executablePath,
     reply(CLASHFX_HELPER_PROTOCOL_VERSION);
 }
 
+- (void)getMihomoCoreStatusWithReply:(dictReplyBlock)reply {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSTask *task = self.mihomoTask;
+        NSMutableDictionary *status = [NSMutableDictionary dictionary];
+        status[@"running"] = @(task && task.isRunning);
+        status[@"pid"] = @(self.mihomoProcessID);
+        if (self.mihomoLaunchID.length > 0) {
+            status[@"launchID"] = self.mihomoLaunchID;
+        }
+        if (self.mihomoLogPath.length > 0) {
+            status[@"logPath"] = self.mihomoLogPath;
+            NSDictionary *attributes = [[NSFileManager defaultManager]
+                attributesOfItemAtPath:self.mihomoLogPath
+                                 error:nil];
+            status[@"logBytes"] = attributes[NSFileSize] ?: @0;
+        }
+        if (self.mihomoLaunchDate) {
+            status[@"startedAt"] = @([self.mihomoLaunchDate timeIntervalSince1970]);
+        }
+        if (self.mihomoLastTerminationSummary.length > 0) {
+            status[@"lastTermination"] = self.mihomoLastTerminationSummary;
+        }
+        reply(status);
+    });
+}
+
+- (void)captureMihomoCoreDiagnosticWithReason:(NSString *)reason
+                                        reply:(stringReplyBlock)reply {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSTask *task = self.mihomoTask;
+        if (!(task && task.isRunning)) {
+            NSString *summary = self.mihomoLastTerminationSummary ?: @"none";
+            reply([NSString stringWithFormat:@"error: core is not running; last termination=%@", summary]);
+            return;
+        }
+
+        pid_t pid = task.processIdentifier;
+        NSString *launchID = self.mihomoLaunchID ?: @"unknown";
+        NSString *homeDir = self.mihomoHomeDir;
+        NSString *coreLogPath = self.mihomoLogPath;
+        NSString *diagnosticReason = reason.length > 0 ? reason : @"unspecified";
+        NSString *diagnosticID = [self newMihomoLaunchID];
+
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            NSString *logDirectory = [homeDir stringByAppendingPathComponent:@".mihomo_core_logs"];
+            [[NSFileManager defaultManager] createDirectoryAtPath:logDirectory
+                                      withIntermediateDirectories:YES
+                                                       attributes:@{NSFilePosixPermissions: @(0755)}
+                                                            error:nil];
+            NSString *samplePath = [logDirectory
+                stringByAppendingPathComponent:[NSString stringWithFormat:
+                    @"mihomo-%@-diagnostic-%@.sample.txt",
+                    launchID,
+                    diagnosticID]];
+
+            BOOL sampled = RunTaskWithTimeout(
+                @"/usr/bin/sample",
+                @[
+                    [NSString stringWithFormat:@"%d", pid],
+                    @"2",
+                    @"1",
+                    @"-file",
+                    samplePath
+                ],
+                6.0
+            );
+            NSString *context = [NSString stringWithFormat:
+                @"ClashFX core diagnostic: reason=%@ pid=%d launch=%@ sampled=%@",
+                diagnosticReason,
+                pid,
+                launchID,
+                sampled ? @"yes" : @"no"];
+            AppendLineToFile(samplePath, context);
+            AppendLineToFile(
+                coreLogPath,
+                [NSString stringWithFormat:
+                    @"[ClashFX Helper] captured core diagnostic reason=%@ sample=%@ result=%@",
+                    diagnosticReason,
+                    samplePath,
+                    sampled ? @"success" : @"failed"]
+            );
+            NSLog(@"[mihomo_core] Captured core diagnostic for pid %d at %@ (success=%@)",
+                  pid,
+                  samplePath,
+                  sampled ? @"yes" : @"no");
+            [self pruneMihomoDiagnosticDirectory:logDirectory keepingPath:samplePath];
+            reply(sampled
+                ? samplePath
+                : [NSString stringWithFormat:@"error: sample failed; diagnostic=%@", samplePath]);
+        });
+    });
+}
+
+- (void)restartMihomoCoreHostWithReply:(stringReplyBlock)reply {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSTask *task = self.mihomoTask;
+        self.mihomoTask = nil;
+        [self terminateMihomoTask:task completion:^{
+            NSLog(@"[mihomo_core] Restarting helper host after an external-core startup failure");
+            reply(nil);
+            dispatch_after(
+                dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)),
+                dispatch_get_main_queue(),
+                ^{
+                    self.shouldQuit = YES;
+                }
+            );
+        }];
+    });
+}
+
 - (void)enableProxyWithPort:(int)port
           socksPort:(int)socksPort
             pac:(NSString *)pac
@@ -506,16 +718,27 @@ static BOOL RunTaskWithTimeout(NSString *executablePath,
     task.executableURL = [NSURL fileURLWithPath:binaryPath];
     task.arguments = @[@"-f", configPath, @"-d", homeDir];
 
-    NSString *logPath = [homeDir stringByAppendingPathComponent:@".mihomo_core.log"];
-    [@"" writeToFile:logPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
-    [[NSFileManager defaultManager] setAttributes:@{NSFilePosixPermissions: @(0644)}
-                                     ofItemAtPath:logPath error:nil];
+    NSString *launchID = [self newMihomoLaunchID];
+    NSString *logPath = [self prepareMihomoLogForHomeDir:homeDir launchID:launchID];
+    NSDate *launchDate = [NSDate date];
+    self.mihomoLaunchID = launchID;
+    self.mihomoLogPath = logPath;
+    self.mihomoHomeDir = homeDir;
+    self.mihomoLaunchDate = launchDate;
+    self.mihomoProcessID = 0;
+    self.mihomoLastTerminationSummary = nil;
 
     NSPipe *pipe = [NSPipe pipe];
     task.standardOutput = pipe;
     task.standardError = pipe;
 
     NSFileHandle *logHandle = [NSFileHandle fileHandleForWritingAtPath:logPath];
+    if (logHandle) {
+        int flags = fcntl(logHandle.fileDescriptor, F_GETFL);
+        if (flags >= 0) {
+            (void)fcntl(logHandle.fileDescriptor, F_SETFL, flags | O_APPEND);
+        }
+    }
     __block BOOL didReportTruncation = NO;
 
     pipe.fileHandleForReading.readabilityHandler = ^(NSFileHandle *handle) {
@@ -545,20 +768,86 @@ static BOOL RunTaskWithTimeout(NSString *executablePath,
         }
     };
 
+    __weak ProxyConfigHelper *weakSelf = self;
+    task.terminationHandler = ^(NSTask *finishedTask) {
+        NSString *reason = finishedTask.terminationReason == NSTaskTerminationReasonUncaughtSignal
+            ? @"signal"
+            : @"exit";
+        NSTimeInterval duration = [[NSDate date] timeIntervalSinceDate:launchDate];
+        NSString *summary = [NSString stringWithFormat:
+            @"launch=%@ pid=%d reason=%@ status=%d duration=%.3fs log=%@",
+            launchID,
+            finishedTask.processIdentifier,
+            reason,
+            finishedTask.terminationStatus,
+            duration,
+            logPath];
+        AppendLineToFile(
+            logPath,
+            [NSString stringWithFormat:@"[ClashFX Helper] terminated %@", summary]
+        );
+        NSLog(@"[mihomo_core] Process terminated %@", summary);
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            ProxyConfigHelper *strongSelf = weakSelf;
+            if (!strongSelf) {
+                return;
+            }
+            if ([strongSelf.mihomoLaunchID isEqualToString:launchID]) {
+                strongSelf.mihomoLastTerminationSummary = summary;
+            }
+            if (strongSelf.mihomoTask == finishedTask) {
+                strongSelf.mihomoTask = nil;
+            }
+        });
+    };
+
     NSError *error = nil;
     [task launchAndReturnError:&error];
     if (error) {
         pipe.fileHandleForReading.readabilityHandler = nil;
         [logHandle closeFile];
+        NSString *summary = [NSString stringWithFormat:
+            @"launch=%@ failed before start: %@",
+            launchID,
+            error.localizedDescription];
+        self.mihomoLastTerminationSummary = summary;
+        AppendLineToFile(logPath, [NSString stringWithFormat:@"[ClashFX Helper] %@", summary]);
         reply([NSString stringWithFormat:@"Launch failed: %@", error.localizedDescription]);
         return;
     }
 
     self.mihomoTask = task;
+    self.mihomoProcessID = task.processIdentifier;
+    AppendLineToFile(
+        logPath,
+        [NSString stringWithFormat:
+            @"[ClashFX Helper] launched id=%@ pid=%d binary=%@ config=%@ home=%@",
+            launchID,
+            task.processIdentifier,
+            binaryPath,
+            configPath,
+            homeDir]
+    );
+    NSLog(@"[mihomo_core] Launched id=%@ pid=%d log=%@",
+          launchID,
+          task.processIdentifier,
+          logPath);
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (!task.isRunning) {
-            NSLog(@"[mihomo_core] Process exited early with status: %d", task.terminationStatus);
+            NSLog(@"[mihomo_core] Process %@ pid %d exited within 1s with status: %d",
+                  launchID,
+                  task.processIdentifier,
+                  task.terminationStatus);
+        } else {
+            NSDictionary *attributes = [[NSFileManager defaultManager]
+                attributesOfItemAtPath:logPath
+                                 error:nil];
+            NSLog(@"[mihomo_core] Process %@ pid %d still running after 1s, log bytes=%@",
+                  launchID,
+                  task.processIdentifier,
+                  attributes[NSFileSize] ?: @0);
         }
     });
 

--- a/ProxyConfigHelper/ProxyConfigRemoteProcessProtocol.h
+++ b/ProxyConfigHelper/ProxyConfigRemoteProcessProtocol.h
@@ -13,7 +13,7 @@ typedef void(^boolReplyBlock)(BOOL);
 typedef void(^dictReplyBlock)(NSDictionary *);
 typedef void(^uintReplyBlock)(NSUInteger);
 
-#define CLASHFX_HELPER_PROTOCOL_VERSION 2
+#define CLASHFX_HELPER_PROTOCOL_VERSION 3
 
 @protocol ProxyConfigRemoteProcessProtocol <NSObject>
 @required
@@ -23,6 +23,14 @@ typedef void(^uintReplyBlock)(NSUInteger);
 @optional
 
 - (void)getProtocolVersion:(uintReplyBlock)reply NS_SWIFT_NAME(getHelperProtocolVersion(_:));
+
+- (void)getMihomoCoreStatusWithReply:(dictReplyBlock)reply
+    NS_SWIFT_NAME(getMihomoCoreStatus(_:));
+
+- (void)captureMihomoCoreDiagnosticWithReason:(NSString *)reason
+                                        reply:(stringReplyBlock)reply;
+
+- (void)restartMihomoCoreHostWithReply:(stringReplyBlock)reply;
 
 @required
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,31 @@
 ### Bug Fixes
 
+- **Enhanced Mode Now Detects Silent Data-Plane Failures** — Runtime monitoring now verifies the core's DIRECT outbound path and DNS resolution in addition to the controller and TUN interface. Three confirmed core-only failures trigger a bounded rebuild, while unavailable system connectivity is treated as inconclusive to avoid restart loops. (#147)
+- **Recovery Captures Evidence Before Restarting the Core** — Every external-core launch now has a unique capped log, launch and termination metadata, and an on-demand process sample. Automatic recovery records this evidence before rebuilding, and a failed startup can restart the Helper host once instead of leaving a stale external core behind. (#147)
+- **Proxy and Rules Views Survive Brief Core Interruptions** — The menu and Dashboard preserve their last valid proxy/rules snapshot when the local controller is temporarily unavailable. The Dashboard clearly marks cached rules as stale instead of showing an empty page, so a recovery no longer looks like the user's rules disappeared. (#147)
+
+### Contributors
+
+- @a51095 — Reported that long-running Enhanced Mode could partially stop loading external sites and recover only after restarting ClashFX. (#147)
+
+---
+
+### 修复
+
+- **增强模式现在可识别数据面的静默失效** — 运行时监控除了检查控制接口和 TUN 网卡，还会验证核心的 DIRECT 出站链路及 DNS 解析。仅当系统直连正常且核心连续三次失败时才会执行有界重建；系统网络本身不可用时会视为无法判定，避免反复重启。 (#147)
+- **重启核心前会先保留诊断证据** — 每次外部核心启动现在都有独立且受容量限制的日志、启动与退出元数据，以及按需进程采样。自动恢复会先记录这些证据再重建；启动失败时也可仅重启一次 Helper 宿主，避免残留外部核心持续阻塞。 (#147)
+- **核心短暂中断时代理与规则界面不再清空** — 本地控制接口暂时不可用时，菜单与控制台会保留最后一次有效的代理和规则快照。控制台会明确提示当前展示的是旧规则，不会再以空白页面表现为“规则消失”。 (#147)
+
+### 贡献者
+
+- @a51095 — 反馈增强模式长时间运行后外部网站可能只能部分加载，必须重启 ClashFX 才恢复的问题。 (#147)
+
+<!-- Previous release notes -->
+
+---
+
+### Bug Fixes
+
 - **Large Delay Tests No Longer Trigger Enhanced Mode Restarts** — Manual benchmarks now share a bounded eight-request queue, cancel cleanly before recovery, and use control-plane health thresholds that tolerate short load spikes. Testing a large proxy group can no longer starve the controller and make ClashFX rebuild a healthy core. The default benchmark endpoint also uses HTTPS, with existing default settings migrated automatically.
 - **Helper Upgrades No Longer Loop or Race App Startup** — ClashFX now compares the bundled and installed Helper reliably, gives privileged operations enough time to finish, validates connecting clients, and keeps the Helper alive briefly while the app reconnects. Startup waits for Helper cleanup before restoring Enhanced Mode, preventing repeated installer prompts and transient “Helper unavailable” failures.
 - **Network Restoration Cannot Freeze Relaunch** — DNS restoration and cache flushing now have strict watchdogs, so a slow system command cannot stall ClashFX for minutes. If an older restore finishes late, the active proxy DNS settings are reapplied instead of being overwritten.


### PR DESCRIPTION
## What

- add runtime DIRECT and DNS probes for Enhanced Mode, with system-direct baselines, failure thresholds, and recovery cooldown
- capture unique capped core logs, launch metadata, termination details, and process samples before rebuilding the external core
- recover the Helper host once after an external-core startup failure
- preserve the last valid proxy and rules snapshots during brief controller interruptions and mark cached Dashboard rules as stale
- bump the Helper protocol and bundle version, and add bilingual Lab release notes

## Why

Issue #147 reports that after long-running System Proxy plus Enhanced Mode, external pages can remain partially loaded until ClashFX is restarted. The prior monitor verified only the controller and TUN interface, so it could miss a live core whose outbound data path or DNS had stalled.

## Safety

Automatic recovery requires three consecutive failures where the core fails but the matching system-direct baseline succeeds. System network failures are treated as inconclusive, manual benchmarks and configuration updates suppress probes, and successful recoveries enter a ten-minute cooldown.

## Checks

- Release universal build succeeds
- SwiftLint: 0 serious violations, 59 existing warnings
- Helper static analysis succeeds with one existing dead-store warning
- core DIRECT probes succeed against both literal-IP endpoints
- core DNS query returns a non-empty answer
- Dashboard stale-rule fallback simulation passes
- localization plists and release-note structure pass
- git diff --check passes