### PR TITLE
fix: improve rules, benchmarks, and Mojave support

### DIFF
--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -7,9 +7,6 @@
 //
 
 import Alamofire
-import AppCenter
-import AppCenterAnalytics
-import AppCenterCrashes
 import Cocoa
 import CocoaLumberjack
 import KeyboardShortcuts
@@ -353,7 +350,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         RemoteConfigManager.shared.autoUpdateCheck()
 
         setupNetworkNotifier()
-        registCrashLogger()
         KeyboardShortCutManager.setup()
         RemoteControlManager.setupMenuItem(separator: externalControlSeparator)
         applyTrayMenuVisibility()
@@ -3852,23 +3848,7 @@ extension AppDelegate {
     }
 }
 
-// MARK: crash hanlder
-
 extension AppDelegate {
-    func registCrashLogger() {
-        #if DEBUG
-            return
-        #else
-            DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-                AppCenter.start(withAppSecret: "dce6e9a3-b6e3-4fd2-9f2d-35c767a99663", services: [
-                    Analytics.self,
-                    Crashes.self
-                ])
-            }
-
-        #endif
-    }
-
     func failLaunchProtect() {
         #if DEBUG
             return

--- a/ClashFX/General/ApiRequest.swift
+++ b/ClashFX/General/ApiRequest.swift
@@ -64,6 +64,11 @@ private final class LimitedAsyncTaskRunner {
 }
 
 class ApiRequest {
+    struct ProviderProxyBenchmarkTarget: Hashable {
+        let providerName: ClashProviderName
+        let proxyName: ClashProxyName
+    }
+
     final class BenchmarkSession {
         private let lock = NSLock()
         private var requests: [UUID: DataRequest] = [:]
@@ -686,7 +691,7 @@ class ApiRequest {
 
     static func benchmarkProxySelection(
         proxyNames: [ClashProxyName],
-        providerNames: Set<ClashProviderName>,
+        providerProxies: [ProviderProxyBenchmarkTarget],
         benchmarkURL: String,
         timeout: Int,
         maxConcurrent: Int = benchmarkMaxConcurrent,
@@ -702,6 +707,7 @@ class ApiRequest {
         typealias DelayTask = LimitedAsyncTaskRunner.Task
         var tasks = [DelayTask]()
         var uniqueProxyNames = Set<ClashProxyName>()
+        var uniqueProviderProxies = Set<ProviderProxyBenchmarkTarget>()
 
         for proxyName in proxyNames where uniqueProxyNames.insert(proxyName).inserted {
             tasks.append { done in
@@ -723,24 +729,37 @@ class ApiRequest {
             }
         }
 
-        for providerName in providerNames.sorted() {
+        let sortedProviderProxies = providerProxies.sorted {
+            if $0.providerName == $1.providerName {
+                return $0.proxyName.localizedStandardCompare($1.proxyName) == .orderedAscending
+            }
+            return $0.providerName.localizedStandardCompare($1.providerName) == .orderedAscending
+        }
+        for target in sortedProviderProxies where uniqueProviderProxies.insert(target).inserted {
             tasks.append { done in
                 guard !session.isCancelled else {
                     done()
                     return
                 }
-                healthCheck(
-                    proxy: providerName,
-                    requestTimeout: benchmarkRequestTimeout(for: timeout),
-                    session: session,
-                    completeHandler: done
-                )
+                getProviderProxyDelay(
+                    providerName: target.providerName,
+                    proxyName: target.proxyName,
+                    benchmarkURL: benchmarkURL,
+                    timeout: timeout,
+                    session: session
+                ) { delay in
+                    if !session.isCancelled {
+                        proxyResult(target.proxyName, delay)
+                    }
+                    done()
+                }
             }
         }
 
         Logger.log(
             "[Proxy Delay] Starting selected benchmark: " +
-                "\(uniqueProxyNames.count) inline, \(providerNames.count) provider, " +
+                "\(uniqueProxyNames.count) inline, " +
+                "\(uniqueProviderProxies.count) provider proxy, " +
                 "max concurrency \(max(1, maxConcurrent))"
         )
         LimitedAsyncTaskRunner(tasks: tasks, maxConcurrent: maxConcurrent)

--- a/ClashFX/Resources/dashboard/config.js
+++ b/ClashFX/Resources/dashboard/config.js
@@ -4,3 +4,80 @@ window.__METACUBEXD_CONFIG__ = {
     (window.__METACUBEXD_CONFIG__ && window.__METACUBEXD_CONFIG__.defaultBackendURL) ||
     `${window.location.protocol}//${window.location.host}`,
 }
+
+;(function installClashFXRuleTimeCompatibility() {
+  const originalFetch = window.fetch.bind(window)
+
+  function isMeaningfulRuleTime(count, value) {
+    if (Number(count) <= 0 || typeof value !== "string") {
+      return false
+    }
+
+    const milliseconds = Date.parse(value)
+    return Number.isFinite(milliseconds) && milliseconds > 0
+  }
+
+  function sanitizeRuleTimes(payload) {
+    if (!payload || typeof payload !== "object") {
+      return false
+    }
+
+    const rules = Array.isArray(payload.rules)
+      ? payload.rules
+      : Object.values(payload.rules || {})
+    let changed = false
+
+    for (const rule of rules) {
+      const extra = rule && rule.extra
+      if (!extra || typeof extra !== "object") {
+        continue
+      }
+
+      if (!isMeaningfulRuleTime(extra.hitCount, extra.hitAt) && "hitAt" in extra) {
+        delete extra.hitAt
+        changed = true
+      }
+      if (!isMeaningfulRuleTime(extra.missCount, extra.missAt) && "missAt" in extra) {
+        delete extra.missAt
+        changed = true
+      }
+    }
+
+    return changed
+  }
+
+  window.fetch = async function (input, init) {
+    const response = await originalFetch(input, init)
+    const inputURL = input instanceof Request ? input.url : input
+    let path
+
+    try {
+      path = new URL(String(inputURL), window.location.href).pathname.replace(/\/+$/, "")
+    } catch (_) {
+      return response
+    }
+
+    if (!path.endsWith("/rules") || !response.ok) {
+      return response
+    }
+
+    let payload
+    try {
+      payload = await response.clone().json()
+    } catch (_) {
+      return response
+    }
+
+    if (!sanitizeRuleTimes(payload)) {
+      return response
+    }
+
+    const headers = new Headers(response.headers)
+    headers.delete("content-length")
+    return new Response(JSON.stringify(payload), {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  }
+})()

--- a/ClashFX/Views/ProxyGroupSpeedTestMenuItem.swift
+++ b/ClashFX/Views/ProxyGroupSpeedTestMenuItem.swift
@@ -153,11 +153,13 @@ private class ProxyGroupSpeedTestMenuItemView: MenuItemBaseView {
         }
 
         var proxies = [ClashProxyName]()
-        var providers = Set<ClashProviderName>()
+        var providerProxies = [ApiRequest.ProviderProxyBenchmarkTarget]()
         for testable in group.speedtestAble {
             switch testable {
-            case let .provider(_, provider):
-                providers.insert(provider)
+            case let .provider(name, provider):
+                providerProxies.append(
+                    .init(providerName: provider, proxyName: name)
+                )
             case let .proxy(name):
                 proxies.append(name)
             }
@@ -181,7 +183,7 @@ private class ProxyGroupSpeedTestMenuItemView: MenuItemBaseView {
 
         ApiRequest.benchmarkProxySelection(
             proxyNames: proxies,
-            providerNames: providers,
+            providerProxies: providerProxies,
             benchmarkURL: Settings.benchMarkUrl,
             timeout: 5000,
             session: session,

--- a/Podfile
+++ b/Podfile
@@ -27,8 +27,6 @@ target 'ClashFX' do
   pod 'RxCocoa', '~> 6.0'
   pod 'CocoaLumberjack/Swift', '~> 3.8.0'
   pod 'Starscream', '~> 4.0.6'
-  pod 'AppCenter/Analytics'
-  pod 'AppCenter/Crashes'
   pod 'Sparkle','~>2.0'
   pod "FlexibleDiff"
   pod 'GzipSwift'
@@ -36,4 +34,3 @@ target 'ClashFX' do
   pod 'SwiftLint'
   pod 'SwiftFormat/CLI', '~> 0.49'
 end
-

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,33 @@
 ### Bug Fixes
 
+- **Never-Matched Rules No Longer Show “57 Years Ago”** — The bundled Dashboard now removes epoch timestamps from rules with no hits or misses, so only real recent-match times are displayed. (#147)
+- **Delay Tests Stay Within the Selected Group** — Provider-backed nodes are now tested individually through their provider instead of benchmarking every node in the provider. Large groups complete faster, avoid unrelated failures, and keep the existing concurrency limit. (#147)
+- **macOS 10.14 Launch Compatibility Is Restored** — Removed the incompatible AppCenter Analytics and Crashes binaries that referenced Objective-C runtime symbols unavailable on Mojave, while keeping ClashFX's macOS 10.14 deployment target. (#197)
+
+### Contributors
+
+- @a51095 — Reported the incorrect recent-match time and the slow, failure-heavy delay-test behavior. (#147)
+- @wzh2dev — Diagnosed the macOS 10.14 launch failure and traced it to AppCenter/PLCrashReporter. (#197)
+
+---
+
+### 修复
+
+- **未命中的规则不再显示“57 年前”** — 内置控制台会移除命中或未命中次数为零时的 Unix 纪元时间，只显示真实的最近匹配时间。 (#147)
+- **延迟测速只测试当前策略组节点** — 来自代理提供者的节点现在会逐个通过对应 Provider 接口测速，不再把 Provider 内所有无关节点一起测试；大型策略组返回更快，也不会再出现大片无关失败，并继续保留并发限制。 (#147)
+- **恢复 macOS 10.14 启动兼容性** — 移除了引用 Mojave 不支持的 Objective-C 运行时符号的 AppCenter Analytics/Crashes 二进制，同时继续保留 ClashFX 的 macOS 10.14 最低系统要求。 (#197)
+
+### 贡献者
+
+- @a51095 — 反馈规则最近命中时间错误，以及延迟测速缓慢并出现大量失败的问题。 (#147)
+- @wzh2dev — 定位 macOS 10.14 启动失败，并追踪到 AppCenter/PLCrashReporter。 (#197)
+
+<!-- Previous release notes -->
+
+---
+
+### Bug Fixes
+
 - **Enhanced Mode Now Detects Silent Data-Plane Failures** — Runtime monitoring now verifies the core's DIRECT outbound path and DNS resolution in addition to the controller and TUN interface. Three confirmed core-only failures trigger a bounded rebuild, while unavailable system connectivity is treated as inconclusive to avoid restart loops. (#147)
 - **Recovery Captures Evidence Before Restarting the Core** — Every external-core launch now has a unique capped log, launch and termination metadata, and an on-demand process sample. Automatic recovery records this evidence before rebuilding, and a failed startup can restart the Helper host once instead of leaving a stale external core behind. (#147)
 - **Proxy and Rules Views Survive Brief Core Interruptions** — The menu and Dashboard preserve their last valid proxy/rules snapshot when the local controller is temporarily unavailable. The Dashboard clearly marks cached rules as stale instead of showing an empty page, so a recovery no longer looks like the user's rules disappeared. (#147)


### PR DESCRIPTION
## What

- hide invalid epoch timestamps for rules that have never matched
- benchmark only the concrete nodes in the selected group, including provider-backed nodes
- remove AppCenter Analytics/Crashes so the advertised macOS 10.14 target launches on Mojave
- add bilingual Lab release notes for issues #147 and #197

## Why

Issue #147 reports “57 years ago” on never-matched rules and slow delay tests with large batches of unrelated failures. Issue #197 identifies a launch-time Mojave crash caused by AppCenter/PLCrashReporter strongly linking `_objc_opt_class`, which is unavailable on macOS 10.14.

## Impact

Rules now show a recent-match time only when a real timestamp exists. Delay tests remain scoped to the selected group and preserve the existing concurrency cap. Removing AppCenter affects only analytics and crash collection; core proxy features are unchanged, and macOS 10.14 remains supported.

## Checks

- Release universal build succeeds
- x86_64 Mach-O remains `minos 10.14`
- final x86_64 executable has no `_objc_opt_class`, AppCenter, MSAC, or PLCrashReporter references
- rule timestamp behavior harness passes
- `node --check ClashFX/Resources/dashboard/config.js` passes
- `git diff --check` passes
