### PR TITLE
fix: speed up URLTest benchmarks and refresh selection

### DIFF
--- a/ClashFX/Views/ProxyGroupSpeedTestMenuItem.swift
+++ b/ClashFX/Views/ProxyGroupSpeedTestMenuItem.swift
@@ -152,15 +152,34 @@ private class ProxyGroupSpeedTestMenuItemView: MenuItemBaseView {
             return
         }
 
+        guard let response = group.enclosingResp else {
+            AppDelegate.shared.finishSpeedTest(
+                session: session,
+                showNotifications: false
+            )
+            return
+        }
+
+        let selectedNames = Set(group.all ?? [])
+        let includedURLTestGroups = response.proxyGroups.filter {
+            $0.type == .urltest && selectedNames.contains($0.name)
+        }
+        var coveredNames = Set(includedURLTestGroups.map(\.name))
+        for autoGroup in includedURLTestGroups {
+            coveredNames.formUnion(autoGroup.all ?? [])
+        }
+
         var proxies = [ClashProxyName]()
         var providerProxies = [ApiRequest.ProviderProxyBenchmarkTarget]()
         for testable in group.speedtestAble {
             switch testable {
             case let .provider(name, provider):
+                guard !coveredNames.contains(name) else { continue }
                 providerProxies.append(
                     .init(providerName: provider, proxyName: name)
                 )
             case let .proxy(name):
+                guard !coveredNames.contains(name) else { continue }
                 proxies.append(name)
             }
         }
@@ -181,34 +200,39 @@ private class ProxyGroupSpeedTestMenuItemView: MenuItemBaseView {
             MenuItemFactory.refreshExistingMenuItems()
         }
 
-        ApiRequest.benchmarkProxySelection(
-            proxyNames: proxies,
-            providerProxies: providerProxies,
-            benchmarkURL: Settings.benchMarkUrl,
+        let benchmarkRemainingProxies = {
+            ApiRequest.benchmarkProxySelection(
+                proxyNames: proxies,
+                providerProxies: providerProxies,
+                benchmarkURL: Settings.benchMarkUrl,
+                timeout: 5000,
+                session: session,
+                proxyResult: { proxyName, delay in
+                    let delayStr = delay == 0 ? NSLocalizedString("fail", comment: "") : "\(delay) ms"
+                    NotificationCenter.default.post(name: .speedTestFinishForProxy,
+                                                    object: nil,
+                                                    userInfo: ["proxyName": proxyName, "delay": delayStr, "rawValue": delay])
+                },
+                completion: finish
+            )
+        }
+
+        guard !includedURLTestGroups.isEmpty else {
+            benchmarkRemainingProxies()
+            return
+        }
+
+        ApiRequest.retestURLTestGroups(
+            in: response,
+            limitedTo: Set(includedURLTestGroups.map(\.name)),
             timeout: 5000,
             session: session,
-            proxyResult: { proxyName, delay in
-                let delayStr = delay == 0 ? NSLocalizedString("fail", comment: "") : "\(delay) ms"
-                NotificationCenter.default.post(name: .speedTestFinishForProxy,
-                                                object: nil,
-                                                userInfo: ["proxyName": proxyName, "delay": delayStr, "rawValue": delay])
-            },
             completion: {
                 guard !session.isCancelled else {
                     finish()
                     return
                 }
-                guard let response = group.enclosingResp else {
-                    finish()
-                    return
-                }
-                ApiRequest.retestURLTestGroups(
-                    in: response,
-                    limitedTo: Set(group.all ?? []),
-                    timeout: 5000,
-                    session: session,
-                    completion: finish
-                )
+                benchmarkRemainingProxies()
             }
         )
     }

--- a/ClashFX/goClash/core_overlay.py
+++ b/ClashFX/goClash/core_overlay.py
@@ -19,6 +19,8 @@ from typing import Iterator
 
 SING_MODULE = "github.com/metacubex/sing"
 EXPECTED_SING_VERSION = "v0.5.7"
+MIHOMO_MODULE = "github.com/metacubex/mihomo"
+EXPECTED_MIHOMO_VERSION = "v1.19.24"
 MODULE_ROOT = pathlib.Path(__file__).resolve().parent
 ORIGINAL_IS_CLOSED = (
     "return IsMulti(err, io.EOF, net.ErrClosed, io.ErrClosedPipe, os.ErrClosed, "
@@ -28,6 +30,17 @@ PATCHED_IS_CLOSED = (
     "return IsMulti(err, io.EOF, net.ErrClosed, io.ErrClosedPipe, os.ErrClosed, "
     "syscall.EPIPE, syscall.ECONNRESET, syscall.ENOTCONN, syscall.ENOTSOCK)"
 )
+ORIGINAL_URL_TEST = """func (u *URLTest) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (map[string]uint16, error) {
+	return u.GroupBase.URLTest(ctx, u.testUrl, expectedStatus)
+}"""
+PATCHED_URL_TEST = """func (u *URLTest) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (map[string]uint16, error) {
+	// Now() can run while the candidates are still being tested and cache a
+	// partial choice for ten seconds. Clear that value once all results are in
+	// so the next selection uses the complete result set and tolerance.
+	u.fastSingle.Reset()
+	defer u.fastSingle.Reset()
+	return u.GroupBase.URLTest(ctx, u.testUrl, expectedStatus)
+}"""
 
 
 def _remove_tree(path: pathlib.Path) -> None:
@@ -42,35 +55,48 @@ def _remove_tree(path: pathlib.Path) -> None:
     shutil.rmtree(path)
 
 
-@contextmanager
-def core_modfile() -> Iterator[str]:
-    # A fresh CI runner has the version in go.sum but no extracted module
-    # directory yet. Download the pinned module before asking Go for its path.
+def _resolve_module(module: str, expected_version: str) -> pathlib.Path:
     subprocess.check_call(
-        ["go", "mod", "download", SING_MODULE],
+        ["go", "mod", "download", module],
         cwd=MODULE_ROOT,
     )
     module_info = subprocess.check_output(
-        ["go", "list", "-m", "-f", "{{.Version}}\n{{.Dir}}", SING_MODULE],
+        ["go", "list", "-m", "-f", "{{.Version}}\n{{.Dir}}", module],
         text=True,
         cwd=MODULE_ROOT,
     ).splitlines()
     if len(module_info) != 2:
-        raise RuntimeError(f"Unable to resolve {SING_MODULE}")
+        raise RuntimeError(f"Unable to resolve {module}")
 
     version, module_dir = module_info
-    if version != EXPECTED_SING_VERSION:
+    if version != expected_version:
         raise RuntimeError(
-            f"Review the ENOTSOCK workaround before updating {SING_MODULE}: "
-            f"expected {EXPECTED_SING_VERSION}, found {version}"
+            f"Review the ClashFX core overlay before updating {module}: "
+            f"expected {expected_version}, found {version}"
+        )
+    return pathlib.Path(module_dir)
+
+
+@contextmanager
+def core_modfile() -> Iterator[str]:
+    # A fresh CI runner has the version in go.sum but no extracted module
+    # directory yet. Download the pinned module before asking Go for its path.
+    sing_source_module = _resolve_module(SING_MODULE, EXPECTED_SING_VERSION)
+    mihomo_source_module = _resolve_module(MIHOMO_MODULE, EXPECTED_MIHOMO_VERSION)
+
+    sing_source = sing_source_module / "common" / "exceptions" / "error.go"
+    sing_original = sing_source.read_text(encoding="utf-8")
+    if sing_original.count(ORIGINAL_IS_CLOSED) != 1:
+        raise RuntimeError(
+            f"The expected IsClosed implementation changed in {sing_source}; "
+            "review the ClashFX overlay"
         )
 
-    source_module = pathlib.Path(module_dir)
-    source = source_module / "common" / "exceptions" / "error.go"
-    original = source.read_text(encoding="utf-8")
-    if original.count(ORIGINAL_IS_CLOSED) != 1:
+    mihomo_source = mihomo_source_module / "adapter" / "outboundgroup" / "urltest.go"
+    mihomo_original = mihomo_source.read_text(encoding="utf-8")
+    if mihomo_original.count(ORIGINAL_URL_TEST) != 1:
         raise RuntimeError(
-            f"The expected IsClosed implementation changed in {source}; "
+            f"The expected URLTest implementation changed in {mihomo_source}; "
             "review the ClashFX overlay"
         )
 
@@ -84,19 +110,31 @@ def core_modfile() -> Iterator[str]:
         )
     try:
         workaround_root.mkdir()
-        replacement_module = workaround_root / "sing"
-        shutil.copytree(source_module, replacement_module)
-        replacement = replacement_module / "common" / "exceptions" / "error.go"
-        os.chmod(replacement, replacement.stat().st_mode | stat.S_IWUSR)
-        replacement.write_text(
-            original.replace(ORIGINAL_IS_CLOSED, PATCHED_IS_CLOSED),
+        sing_replacement_module = workaround_root / "sing"
+        shutil.copytree(sing_source_module, sing_replacement_module)
+        sing_replacement = sing_replacement_module / "common" / "exceptions" / "error.go"
+        os.chmod(sing_replacement, sing_replacement.stat().st_mode | stat.S_IWUSR)
+        sing_replacement.write_text(
+            sing_original.replace(ORIGINAL_IS_CLOSED, PATCHED_IS_CLOSED),
+            encoding="utf-8",
+        )
+
+        mihomo_replacement_module = workaround_root / "mihomo"
+        shutil.copytree(mihomo_source_module, mihomo_replacement_module)
+        mihomo_replacement = (
+            mihomo_replacement_module / "adapter" / "outboundgroup" / "urltest.go"
+        )
+        os.chmod(mihomo_replacement, mihomo_replacement.stat().st_mode | stat.S_IWUSR)
+        mihomo_replacement.write_text(
+            mihomo_original.replace(ORIGINAL_URL_TEST, PATCHED_URL_TEST),
             encoding="utf-8",
         )
 
         modfile = temp_dir / "clashfx.mod"
         modfile.write_text(
             (MODULE_ROOT / "go.mod").read_text(encoding="utf-8") +
-            f"\nreplace {SING_MODULE} => ./.clashfx-core-workaround/sing\n",
+            f"\nreplace {SING_MODULE} => ./.clashfx-core-workaround/sing\n" +
+            f"replace {MIHOMO_MODULE} => ./.clashfx-core-workaround/mihomo\n",
             encoding="utf-8",
         )
         shutil.copy2(MODULE_ROOT / "go.sum", temp_dir / "clashfx.sum")

--- a/ClashFX/goClash/main_test.go
+++ b/ClashFX/goClash/main_test.go
@@ -1,15 +1,114 @@
 package main
 
 import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
 	"syscall"
 	"testing"
+	"time"
 
+	A "github.com/metacubex/mihomo/adapter"
+	"github.com/metacubex/mihomo/adapter/outbound"
+	OG "github.com/metacubex/mihomo/adapter/outboundgroup"
+	P "github.com/metacubex/mihomo/adapter/provider"
+	C "github.com/metacubex/mihomo/constant"
+	CP "github.com/metacubex/mihomo/constant/provider"
 	E "github.com/metacubex/sing/common/exceptions"
 )
+
+type delayedURLTestAdapter struct {
+	*outbound.Base
+	mu    sync.RWMutex
+	delay time.Duration
+}
+
+func newDelayedURLTestAdapter(name string, delay time.Duration) *delayedURLTestAdapter {
+	return &delayedURLTestAdapter{
+		Base:  outbound.NewBase(outbound.BaseOption{Name: name, Type: C.Direct}),
+		delay: delay,
+	}
+}
+
+func (a *delayedURLTestAdapter) setDelay(delay time.Duration) {
+	a.mu.Lock()
+	a.delay = delay
+	a.mu.Unlock()
+}
+
+func (a *delayedURLTestAdapter) DialContext(context.Context, *C.Metadata) (C.Conn, error) {
+	a.mu.RLock()
+	delay := a.delay
+	a.mu.RUnlock()
+	time.Sleep(delay)
+
+	client, server := net.Pipe()
+	go func() {
+		defer server.Close()
+		request, err := http.ReadRequest(bufio.NewReader(server))
+		if err != nil {
+			return
+		}
+		_ = request.Body.Close()
+		_, _ = fmt.Fprint(server, "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+	}()
+	return outbound.NewConn(client, a), nil
+}
 
 func TestClosedTunSocketIsTreatedAsClosed(t *testing.T) {
 	if !E.IsClosed(syscall.ENOTSOCK) {
 		t.Fatal("ENOTSOCK must stop the Darwin TUN read loop")
+	}
+}
+
+func TestURLTestRecomputesSelectionAfterAllCandidatesFinish(t *testing.T) {
+	const testURL = "http://clashfx.test/generate_204"
+	firstAdapter := newDelayedURLTestAdapter("first", 10*time.Millisecond)
+	secondAdapter := newDelayedURLTestAdapter("second", 80*time.Millisecond)
+	firstProxy := A.NewProxy(firstAdapter)
+	secondProxy := A.NewProxy(secondAdapter)
+	proxies := []C.Proxy{firstProxy, secondProxy}
+	healthCheck := P.NewHealthCheck(proxies, testURL, 1000, 0, true, nil)
+	proxyProvider, err := P.NewCompatibleProvider("test", proxies, healthCheck)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proxyProvider.Close()
+
+	group := OG.NewURLTest(
+		&OG.GroupCommonOption{Name: "auto", URL: testURL},
+		[]CP.ProxyProvider{proxyProvider},
+	)
+	if _, err := group.URLTest(context.Background(), testURL, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := group.Now(); got != "first" {
+		t.Fatalf("initial selection = %q, want first", got)
+	}
+
+	firstAdapter.setDelay(250 * time.Millisecond)
+	secondAdapter.setDelay(20 * time.Millisecond)
+	done := make(chan error, 1)
+	go func() {
+		_, err := group.URLTest(context.Background(), testURL, nil)
+		done <- err
+	}()
+
+	deadline := time.Now().Add(150 * time.Millisecond)
+	for secondProxy.LastDelayForTestUrl(testURL) >= 50 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := group.Now(); got != "first" {
+		t.Fatalf("selection during partial results = %q, want cached first", got)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if got := group.Now(); got != "second" {
+		t.Fatalf("selection after complete results = %q, want second", got)
 	}
 }
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,29 @@
 ### Bug Fixes
 
+- **Selected-Group Delay Tests Avoid Duplicate Work** — When a selector contains a URLTest group and the same leaf nodes, ClashFX now tests that automatic group once with its configured URL and skips individually retesting the nodes it already covered. Large groups finish sooner without bringing back provider-wide health checks. (#147)
+- **Automatic Groups Re-evaluate After Complete Results** — A URLTest started from the controller now clears any choice cached while candidates were still responding, then applies the configured tolerance to the complete result set. Early responses can no longer remain selected after slower candidates finish. (#147)
+
+### Contributors
+
+- @a51095 — Reported the remaining selected-group delay-test slowdown and automatic-group selection behavior. (#147)
+
+---
+
+### 修复
+
+- **策略组测速不再重复测试相同节点** — 当手动选择组同时包含自动策略组及其节点时，ClashFX 现在会按自动策略组自己的地址整组测试一次，并跳过已覆盖节点的逐个重复测速；大型策略组会更快完成，也不会重新触发 Provider 全量测速。 (#147)
+- **自动策略会在完整结果返回后重新判断** — 通过控制接口触发 URLTest 时，核心现在会清除测速过程中提前缓存的选择，再基于完整结果和订阅配置的容差重新判断；较早返回的节点不会在整组测速结束后仍被错误保留。 (#147)
+
+### 贡献者
+
+- @a51095 — 反馈策略组测速仍然偏慢，以及自动策略选择结果异常的问题。 (#147)
+
+<!-- Previous release notes -->
+
+---
+
+### Bug Fixes
+
 - **Never-Matched Rules No Longer Show “57 Years Ago”** — The bundled Dashboard now removes epoch timestamps from rules with no hits or misses, so only real recent-match times are displayed. (#147)
 - **Delay Tests Stay Within the Selected Group** — Provider-backed nodes are now tested individually through their provider instead of benchmarking every node in the provider. Large groups complete faster, avoid unrelated failures, and keep the existing concurrency limit. (#147)
 - **macOS 10.14 Launch Compatibility Is Restored** — Removed the incompatible AppCenter Analytics and Crashes binaries that referenced Objective-C runtime symbols unavailable on Mojave, while keeping ClashFX's macOS 10.14 deployment target. (#197)


### PR DESCRIPTION
## What

- test included URLTest groups once and skip individually retesting nodes they already cover
- clear URLTest selection caches before and after controller-triggered group tests
- add a regression test for partial-result selection caching
- add bilingual Lab release notes for issue #147

## Why

Issue #147 reports that selected-group delay tests remain slower than Mihomo default behavior and that automatic selection can appear to keep an early response. The selected-group workflow repeated overlapping leaf tests, while URLTest could cache a choice observed before every candidate finished.

## Impact

Large selected groups avoid duplicate work. Automatic groups re-evaluate from the complete result set while continuing to honor the subscription tolerance, so a small latency difference does not force unnecessary switching.

## Checks

- Go full test suite with the core overlay passes
- URLTest regression test passes five consecutive runs
- Go race detector passes the regression test
- Debug workspace build succeeds
- universal arm64/x86_64 core rebuild succeeds and the embedded core matches the rebuilt artifact
- git diff --check passes