### PR TITLE
release: update appcast.xml for v1.1.9.7

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -6,6 +6,25 @@
     <description>Most recent ClashFX updates</description>
     <language>en</language>
     <item>
+  <title>Version 1.1.9.7 (Lab)</title>
+  <description><![CDATA[
+    <h2>ClashFX v1.1.9.7 (Lab)</h2><ul><li><strong>Delay Test Menu Stays Open on the First Click</strong> — Starting a delay test no longer disables the active custom menu item, which could make AppKit close the proxy menu before showing progress. Repeat clicks are still rejected by the active benchmark session.</li><li><strong>Never-Matched Rules Reliably Hide Epoch Times</strong> — Rule timestamps are now normalized in ClashFX's native Dashboard response layer, including cached snapshots, so release-time Dashboard replacement can no longer bring back “57 years ago.” (#147)</li><li><strong>Selected-Group Delay Tests Avoid Duplicate Work</strong> — When a selector contains a URLTest group and the same leaf nodes, ClashFX now tests that automatic group once with its configured URL and skips individually retesting the nodes it already covered. Large groups finish sooner without bringing back provider-wide health checks. (#147)</li><li><strong>Automatic Groups Re-evaluate After Complete Results</strong> — A URLTest started from the controller now clears any choice cached while candidates were still responding, then applies the configured tolerance to the complete result set. Early responses can no longer remain selected after slower candidates finish. (#147)</li></ul>
+  ]]></description>
+  <pubDate>Tue, 11 Aug 2026 07:18:49 +0000</pubDate>
+  <sparkle:version>1001009007</sparkle:version>
+  <sparkle:shortVersionString>1.1.9.7</sparkle:shortVersionString>
+            <sparkle:channel>lab</sparkle:channel>
+          <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
+  <enclosure
+    url="https://github.com/Clash-FX/ClashFX/releases/download/1.1.9.7/ClashFX.dmg"
+    sparkle:version="1001009007"
+    sparkle:shortVersionString="1.1.9.7"
+    sparkle:edSignature="7mHmpNnmaPDPRcr3KrKk25xJWQ9nx8esSeK9hG4xhRrGjN8efhiUew/CJhwATbBaMAAFB/cjyqRdtFK7R9X5DA=="
+    length="95135672"
+    type="application/x-apple-diskimage"
+  />
+</item>
+    <item>
   <title>Version 1.1.9.6 (Lab)</title>
   <description><![CDATA[
     <h2>ClashFX v1.1.9.6 (Lab)</h2><ul><li><strong>Selected-Group Delay Tests Avoid Duplicate Work</strong> — When a selector contains a URLTest group and the same leaf nodes, ClashFX now tests that automatic group once with its configured URL and skips individually retesting the nodes it already covered. Large groups finish sooner without bringing back provider-wide health checks. (#147)</li><li><strong>Automatic Groups Re-evaluate After Complete Results</strong> — A URLTest started from the controller now clears any choice cached while candidates were still responding, then applies the configured tolerance to the complete result set. Early responses can no longer remain selected after slower candidates finish. (#147)</li></ul>


### PR DESCRIPTION
Auto-generated by CI. Updates Sparkle appcast for v1.1.9.7.