### PR TITLE
fix: persist custom benchmark URLs

### DIFF
--- a/ClashFX.xcodeproj/project.pbxproj
+++ b/ClashFX.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		C30200000000000000000003 /* StartupProxyRecoveryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30200000000000000000001 /* StartupProxyRecoveryPolicy.swift */; };
 		C30300000000000000000002 /* DiagnosticFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30300000000000000000001 /* DiagnosticFormatting.swift */; };
 		C30300000000000000000003 /* DiagnosticFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30300000000000000000001 /* DiagnosticFormatting.swift */; };
+		C30400000000000000000002 /* BenchmarkURLSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30400000000000000000001 /* BenchmarkURLSettings.swift */; };
+		C30400000000000000000003 /* BenchmarkURLSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30400000000000000000001 /* BenchmarkURLSettings.swift */; };
 		03B729DE29C62F46117B82A2 /* LabSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6174820C53D16D319C2DB8E /* LabSupport.swift */; };
 		079C0498F443DE06CFD1A2E0 /* FormHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1541315BE9AC1A5200C8FDA /* FormHelpers.swift */; };
 		0AD7506B2A5B9A04001FFBBD /* ConnectionLeftPannelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD7506A2A5B9A04001FFBBD /* ConnectionLeftPannelViewModel.swift */; };
@@ -201,6 +203,7 @@
 		C30100000000000000000015 /* BenchmarkRegressionSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkRegressionSupport.swift; sourceTree = "<group>"; };
 		C30200000000000000000001 /* StartupProxyRecoveryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupProxyRecoveryPolicy.swift; sourceTree = "<group>"; };
 		C30300000000000000000001 /* DiagnosticFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticFormatting.swift; sourceTree = "<group>"; };
+		C30400000000000000000001 /* BenchmarkURLSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkURLSettings.swift; sourceTree = "<group>"; };
 		06252EC2F039BCAFB08D62E4 /* DNSConfigViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DNSConfigViewController.swift; sourceTree = "<group>"; };
 		0AD7506A2A5B9A04001FFBBD /* ConnectionLeftPannelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLeftPannelViewModel.swift; sourceTree = "<group>"; };
 		0AD7506C2A5B9B26001FFBBD /* ConnectionLeftTextCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLeftTextCellView.swift; sourceTree = "<group>"; };
@@ -475,6 +478,7 @@
 				49CF3B6420CEE06C001EBF94 /* ConfigManager.swift */,
 				C30200000000000000000001 /* StartupProxyRecoveryPolicy.swift */,
 				C30300000000000000000001 /* DiagnosticFormatting.swift */,
+				C30400000000000000000001 /* BenchmarkURLSettings.swift */,
 				495BFB8721919B9800C8779D /* RemoteConfigManager.swift */,
 				4952C3BE2115C7CA004A4FA8 /* MenuItemFactory.swift */,
 				F935B2FB23085515009E4D33 /* SystemProxyManager.swift */,
@@ -1060,6 +1064,7 @@
 				C30100000000000000000014 /* ClashProvider.swift in Sources */,
 				C30200000000000000000003 /* StartupProxyRecoveryPolicy.swift in Sources */,
 				C30300000000000000000003 /* DiagnosticFormatting.swift in Sources */,
+				C30400000000000000000003 /* BenchmarkURLSettings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1116,6 +1121,7 @@
 				49CF3B6520CEE06C001EBF94 /* ConfigManager.swift in Sources */,
 				C30200000000000000000002 /* StartupProxyRecoveryPolicy.swift in Sources */,
 				C30300000000000000000002 /* DiagnosticFormatting.swift in Sources */,
+				C30400000000000000000002 /* BenchmarkURLSettings.swift in Sources */,
 				49870ADB2AA75DC7002B106B /* TerminalCleanUpAction.swift in Sources */,
 				F9E754D0239CC21F00CEE7CC /* WebPortalManager.swift in Sources */,
 				495BFB8821919B9800C8779D /* RemoteConfigManager.swift in Sources */,

--- a/ClashFX/Base.lproj/Main.storyboard
+++ b/ClashFX/Base.lproj/Main.storyboard
@@ -349,17 +349,23 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="m7z-Fp-ctz">
-                                                                    <rect key="frame" x="139" y="0.0" width="251" height="20"/>
+                                                                    <rect key="frame" x="139" y="0.0" width="190" height="20"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="nhC-xY-dyM">
-                                                                        <numberFormatter key="formatter" formatterBehavior="default10_4" localizesFormat="NO" usesGroupingSeparator="NO" formatWidth="-1" groupingSize="0" minimumIntegerDigits="1" maximumIntegerDigits="42" id="WfP-3f-zii">
-                                                                            <real key="minimum" value="0.0"/>
-                                                                            <real key="maximum" value="65533"/>
-                                                                        </numberFormatter>
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
+                                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="benchmark-url-save">
+                                                                    <rect key="frame" x="335" y="-2" width="61" height="25"/>
+                                                                    <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="benchmark-url-save-cell">
+                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                        <font key="font" metaFont="smallSystem"/>
+                                                                    </buttonCell>
+                                                                    <connections>
+                                                                        <action selector="actionSaveBenchmarkURL:" target="kma-mp-ncL" id="benchmark-url-save-action"/>
+                                                                    </connections>
+                                                                </button>
                                                             </subviews>
                                                             <constraints>
                                                                 <constraint firstItem="m7z-Fp-ctz" firstAttribute="top" secondItem="dcS-bg-IKd" secondAttribute="top" id="4hg-YN-oeF"/>
@@ -368,7 +374,9 @@
                                                                 <constraint firstAttribute="bottom" secondItem="m7z-Fp-ctz" secondAttribute="bottom" id="GVa-xd-2ok"/>
                                                                 <constraint firstItem="Rkp-p5-5Uv" firstAttribute="centerY" secondItem="dcS-bg-IKd" secondAttribute="centerY" id="TYY-wj-XSb"/>
                                                                 <constraint firstItem="Rkp-p5-5Uv" firstAttribute="leading" secondItem="dcS-bg-IKd" secondAttribute="leading" id="UMy-Lv-yml"/>
-                                                                <constraint firstAttribute="trailing" secondItem="m7z-Fp-ctz" secondAttribute="trailing" id="ayK-9c-uAf"/>
+                                                                <constraint firstItem="benchmark-url-save" firstAttribute="leading" secondItem="m7z-Fp-ctz" secondAttribute="trailing" constant="8" symbolic="YES" id="benchmark-url-save-leading"/>
+                                                                <constraint firstItem="benchmark-url-save" firstAttribute="centerY" secondItem="dcS-bg-IKd" secondAttribute="centerY" id="benchmark-url-save-center"/>
+                                                                <constraint firstAttribute="trailing" secondItem="benchmark-url-save" secondAttribute="trailing" id="benchmark-url-save-trailing"/>
                                                             </constraints>
                                                         </customView>
                                                     </subviews>
@@ -573,6 +581,7 @@
                         <outlet property="apiPortTextField" destination="xJH-gA-vcL" id="L8f-GZ-BYW"/>
                         <outlet property="apiSecretOverrideButton" destination="N0V-ac-Acm" id="n9x-y4-XsR"/>
                         <outlet property="apiSecretTextField" destination="CE4-Aa-FiI" id="po3-LI-T3l"/>
+                        <outlet property="benchmarkURLSaveButton" destination="benchmark-url-save" id="benchmark-url-save-outlet"/>
                         <outlet property="ignoreListTextView" destination="JDw-FW-A2o" id="fhs-QW-Ug6"/>
                         <outlet property="tunRouteExcludeTextView" destination="UuX-eK-vWq" id="iK2-ZL-s3Q"/>
                         <outlet property="ipv6Button" destination="buf-aL-Tkl" id="s3h-2l-ik5"/>

--- a/ClashFX/General/Managers/BenchmarkURLSettings.swift
+++ b/ClashFX/General/Managers/BenchmarkURLSettings.swift
@@ -1,0 +1,21 @@
+//
+//  BenchmarkURLSettings.swift
+//  ClashFX
+//
+
+import Foundation
+
+enum BenchmarkURLSettings {
+    static func normalizedURL(_ rawValue: String, defaultURL: String) -> String? {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return defaultURL }
+        guard let components = URLComponents(string: value),
+              let scheme = components.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              components.host?.isEmpty == false
+        else {
+            return nil
+        }
+        return value
+    }
+}

--- a/ClashFX/ViewControllers/Settings/GeneralSettingViewController.swift
+++ b/ClashFX/ViewControllers/Settings/GeneralSettingViewController.swift
@@ -29,6 +29,7 @@ class GeneralSettingViewController: NSViewController {
 
     @IBOutlet var ipv6Button: NSButton!
     @IBOutlet var speedTestUrlField: NSTextField!
+    @IBOutlet var benchmarkURLSaveButton: NSButton!
 
     var disposeBag = DisposeBag()
     override func viewDidLoad() {
@@ -36,6 +37,14 @@ class GeneralSettingViewController: NSViewController {
         installDockIconToggle()
         speedTestUrlField.stringValue = Settings.benchMarkUrl
         speedTestUrlField.placeholderString = Settings.defaultBenchmarkUrl
+        benchmarkURLSaveButton.title = NSLocalizedString("Save", comment: "")
+        speedTestUrlField.rx.text
+            .compactMap { $0 }
+            .distinctUntilChanged()
+            .subscribe(onNext: { [weak self] _ in
+                self?.persistBenchmarkURL()
+            })
+            .disposed(by: disposeBag)
         ignoreListTextView.string = Settings.proxyIgnoreList.joined(separator: ",")
         let tunRouteExcludes = Settings.normalizeAndPersistTunRouteExcludeList()
         tunRouteExcludeTextView.string = Settings.tunRouteExcludeRawText.isEmpty
@@ -207,13 +216,35 @@ class GeneralSettingViewController: NSViewController {
 
     override func viewWillDisappear() {
         super.viewWillDisappear()
-        let url = speedTestUrlField.stringValue
-        if url.isUrlVaild() || url.isEmpty {
-            Settings.benchMarkUrl = url
-        }
+        persistBenchmarkURL()
         SSIDSuspendTool.shared.showNoticeOnNotPermission = true
         SSIDSuspendTool.shared.requestPermissionIfNeed()
         SSIDSuspendTool.shared.update()
+    }
+
+    @IBAction func actionSaveBenchmarkURL(_: Any) {
+        guard persistBenchmarkURL() else {
+            NSSound.beep()
+            return
+        }
+        speedTestUrlField.stringValue = Settings.benchMarkUrl
+        view.window?.makeFirstResponder(nil)
+    }
+
+    @discardableResult
+    private func persistBenchmarkURL() -> Bool {
+        guard let url = BenchmarkURLSettings.normalizedURL(
+            speedTestUrlField.stringValue,
+            defaultURL: Settings.defaultBenchmarkUrl
+        ) else {
+            speedTestUrlField.textColor = .systemRed
+            benchmarkURLSaveButton.isEnabled = false
+            return false
+        }
+        Settings.benchMarkUrl = url
+        speedTestUrlField.textColor = .controlTextColor
+        benchmarkURLSaveButton.isEnabled = true
+        return true
     }
 
     @IBAction func actionResetIgnoreList(_: Any) {

--- a/ClashFXTests/BenchmarkRegressionTests.swift
+++ b/ClashFXTests/BenchmarkRegressionTests.swift
@@ -48,6 +48,43 @@ final class DiagnosticFormattingTests: XCTestCase {
     }
 }
 
+final class BenchmarkURLSettingsTests: XCTestCase {
+    func testValidBenchmarkURLIsTrimmedAndPreserved() {
+        XCTAssertEqual(
+            BenchmarkURLSettings.normalizedURL(
+                "  https://www.gstatic.com/generate_204  ",
+                defaultURL: "https://cp.cloudflare.com/generate_204"
+            ),
+            "https://www.gstatic.com/generate_204"
+        )
+    }
+
+    func testEmptyBenchmarkURLRestoresDefault() {
+        XCTAssertEqual(
+            BenchmarkURLSettings.normalizedURL(
+                "  ",
+                defaultURL: "https://cp.cloudflare.com/generate_204"
+            ),
+            "https://cp.cloudflare.com/generate_204"
+        )
+    }
+
+    func testInvalidBenchmarkURLDoesNotReplaceSavedValue() {
+        XCTAssertNil(
+            BenchmarkURLSettings.normalizedURL(
+                "gstatic.com/generate_204",
+                defaultURL: "https://cp.cloudflare.com/generate_204"
+            )
+        )
+        XCTAssertNil(
+            BenchmarkURLSettings.normalizedURL(
+                "file:///tmp/generate_204",
+                defaultURL: "https://cp.cloudflare.com/generate_204"
+            )
+        )
+    }
+}
+
 final class BenchmarkRegressionTests: XCTestCase {
     private func snapshot(_ proxyJSON: [[String: Any]]) -> ClashProxyResp {
         let proxies = Dictionary(uniqueKeysWithValues: proxyJSON.compactMap { proxy -> (String, Any)? in

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,27 @@
 ### Bug Fixes
 
+- **Custom Benchmark URLs Save Reliably** — The proxy delay-test URL field now accepts HTTP and HTTPS addresses correctly and saves valid changes immediately, with an explicit Save button for confirmation. Clearing the field restores the default endpoint, while invalid input no longer overwrites the last working URL. (#147)
+
+### Contributors
+
+- @a51095 — Reported that changing the proxy delay-test URL reverted after leaving Settings. (#147)
+
+---
+
+### 修复
+
+- **自定义测速地址现在可以正常保存** — 代理延迟测速地址输入框现在会正确接受 HTTP 和 HTTPS 地址，合法修改会立即保存，也可以点击“保存”确认。清空输入框会恢复默认地址，无效内容不会覆盖上一次可用的设置。 (#147)
+
+### 贡献者
+
+- @a51095 — 反馈修改代理延迟测速地址后离开设置页面会恢复原值的问题。 (#147)
+
+<!-- Previous release notes -->
+
+---
+
+### Bug Fixes
+
 - **Diagnostic Reports Protect Local Details** — The complete diagnostic report now removes macOS home paths and usernames, local IP and MAC addresses, hostnames, credentials, and other machine-specific details before it is copied for sharing. (#147)
 - **Log Times and the Latest Log Are Easier to Find** — Log lines and filenames now use local time with an explicit UTC offset. “Open Log Folder” also selects the newest log directly instead of relying on Finder's current sort order. (#147)
 


### PR DESCRIPTION
## What changed

- accept HTTP and HTTPS benchmark URLs instead of treating the field as numeric
- save valid edits immediately and provide an explicit Save button
- restore the default endpoint when cleared and preserve the last valid value on invalid input
- add focused regression tests and prepare Lab 1.1.10.1 release notes

## Why

The benchmark URL previously persisted only when the settings view disappeared, and the storyboard field had a number formatter. Valid URLs could therefore be rejected or appear to revert.

## Validation

- 3 focused unhosted XCTest cases passed
- isolated Release build passed
- macOS deployment target remains 10.14
- installed ClashFX PID remained unchanged; no build-product app was launched