### PR TITLE
release: update appcast.xml for v1.1.10.1

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -6,6 +6,25 @@
     <description>Most recent ClashFX updates</description>
     <language>en</language>
     <item>
+  <title>Version 1.1.10.1 (Lab)</title>
+  <description><![CDATA[
+    <h2>ClashFX v1.1.10.1 (Lab)</h2><ul><li><strong>Custom Benchmark URLs Save Reliably</strong> — The proxy delay-test URL field now accepts HTTP and HTTPS addresses correctly and saves valid changes immediately, with an explicit Save button for confirmation. Clearing the field restores the default endpoint, while invalid input no longer overwrites the last working URL. (#147)</li></ul>
+  ]]></description>
+  <pubDate>Thu, 13 Aug 2026 07:37:34 +0000</pubDate>
+  <sparkle:version>1001010001</sparkle:version>
+  <sparkle:shortVersionString>1.1.10.1</sparkle:shortVersionString>
+            <sparkle:channel>lab</sparkle:channel>
+          <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
+  <enclosure
+    url="https://github.com/Clash-FX/ClashFX/releases/download/1.1.10.1/ClashFX.dmg"
+    sparkle:version="1001010001"
+    sparkle:shortVersionString="1.1.10.1"
+    sparkle:edSignature="xg/4Ad3a2kagk3NhxOSB2v+a5HcK4XnI7BHkr3tzDNkE1UMscbOdP2quGkyaB7kOOt5N0Tgu+tVhNfLhnDPcBw=="
+    length="95079082"
+    type="application/x-apple-diskimage"
+  />
+</item>
+    <item>
   <title>Version 1.1.10</title>
   <description><![CDATA[
     <h2>ClashFX v1.1.10</h2><ul><li><strong>Diagnostic Reports Protect Local Details</strong> — The complete diagnostic report now removes macOS home paths and usernames, local IP and MAC addresses, hostnames, credentials, and other machine-specific details before it is copied for sharing. (#147)</li><li><strong>Log Times and the Latest Log Are Easier to Find</strong> — Log lines and filenames now use local time with an explicit UTC offset. “Open Log Folder” also selects the newest log directly instead of relying on Finder's current sort order. (#147)</li></ul>


### PR DESCRIPTION
Auto-generated by CI. Updates Sparkle appcast for v1.1.10.1.