### PR TITLE
fix: prepare Lab 1.1.10.9 reliability fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,7 @@ jobs:
 
         echo "Found app at: $APP_PATH"
         cp -R "$APP_PATH" ./ClashFX.app
+        bash scripts/verify-dashboard-compatibility-bundle.sh ./ClashFX.app
 
         DSYM_PATH=$(find ./build_derived_data/Build/Products/Release -name "ClashFX.app.dSYM" -type d | head -n 1)
         if [ -n "$DSYM_PATH" ]; then
@@ -132,6 +133,20 @@ jobs:
         ln -s /Applications /tmp/dmg_temp/Applications
         hdiutil create -volname "ClashFX" -srcfolder /tmp/dmg_temp -ov -format UDZO -imagekey zlib-level=6 -fs HFS+ -size 300m ClashFX.dmg
         rm -rf /tmp/dmg_temp
+        hdiutil verify ClashFX.dmg
+        DMG_VERIFY_DIR=$(mktemp -d /tmp/clashfx-dmg-verify.XXXXXX)
+        DMG_MOUNT_POINT="$DMG_VERIFY_DIR/mount"
+        mkdir "$DMG_MOUNT_POINT"
+        cleanup_dmg_verification() {
+          hdiutil detach "$DMG_MOUNT_POINT" -quiet 2>/dev/null || true
+          rmdir "$DMG_MOUNT_POINT" "$DMG_VERIFY_DIR" 2>/dev/null || true
+        }
+        trap cleanup_dmg_verification EXIT
+        hdiutil attach ClashFX.dmg -nobrowse -readonly -mountpoint "$DMG_MOUNT_POINT"
+        bash scripts/verify-dashboard-compatibility-bundle.sh "$DMG_MOUNT_POINT/ClashFX.app"
+        hdiutil detach "$DMG_MOUNT_POINT" -quiet
+        trap - EXIT
+        rmdir "$DMG_MOUNT_POINT" "$DMG_VERIFY_DIR"
         echo "DMG created: $(ls -lh ClashFX.dmg)"
 
     - name: sign dmg with sparkle

--- a/ClashFX.xcodeproj/project.pbxproj
+++ b/ClashFX.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		49722FF0211F338B00650A41 /* EventStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49722FEB211F338B00650A41 /* EventStream.swift */; };
 		49722FF1211F338B00650A41 /* Witness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49722FEC211F338B00650A41 /* Witness.swift */; };
 		49761DA721C9497000AE13EF /* dashboard in Resources */ = {isa = PBXBuildFile; fileRef = 49761DA621C9497000AE13EF /* dashboard */; };
+		CF221001DA5A000000000001 /* DashboardCompatibility in Resources */ = {isa = PBXBuildFile; fileRef = CF221002DA5A000000000001 /* DashboardCompatibility */; };
 		49769FB427E9B3E400E3D664 /* LoginKitWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 49D8276727E9B01700159D93 /* LoginKitWrapper.m */; };
 		4981C88B216BAE4A008CC14A /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4981C88D216BAE4A008CC14A /* Localizable.strings */; };
 		4982F51F2344A216008804B0 /* Cgo+Convert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4982F51E2344A216008804B0 /* Cgo+Convert.swift */; };
@@ -270,6 +271,7 @@
 		49722FEC211F338B00650A41 /* Witness.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Witness.swift; sourceTree = "<group>"; };
 		49722FED211F338B00650A41 /* Witness.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Witness.h; sourceTree = "<group>"; };
 		49761DA621C9497000AE13EF /* dashboard */ = {isa = PBXFileReference; lastKnownFileType = folder; path = dashboard; sourceTree = "<group>"; };
+		CF221002DA5A000000000001 /* DashboardCompatibility */ = {isa = PBXFileReference; lastKnownFileType = folder; path = DashboardCompatibility; sourceTree = "<group>"; };
 		4981C887216BAB8A008CC14A /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Main.strings"; sourceTree = "<group>"; };
 		4981C88C216BAE4A008CC14A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4981C88E216BAE4D008CC14A /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -612,6 +614,7 @@
 				49A1C0F02F00000000000001 /* AppIcons */,
 				49A1C0F22F00000000000001 /* MenuIcons */,
 				49761DA621C9497000AE13EF /* dashboard */,
+				CF221002DA5A000000000001 /* DashboardCompatibility */,
 				4989F98D20D0AE990001E564 /* sampleConfig.yaml */,
 			);
 			path = Resources;
@@ -970,6 +973,7 @@
 			files = (
 				4969E73D2A5E3CB20012E005 /* ConnectionDetailInfoGeneralView.xib in Resources */,
 				49761DA721C9497000AE13EF /* dashboard in Resources */,
+				CF221001DA5A000000000001 /* DashboardCompatibility in Resources */,
 				4929F677258CD89B00A435F6 /* Country.mmdb.gz in Resources */,
 				CF000001AAAA000000000001 /* geosite.dat.gz in Resources */,
 				4981C88B216BAE4A008CC14A /* Localizable.strings in Resources */,

--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -3870,6 +3870,7 @@ extension AppDelegate {
         guard let session = beginSpeedTest(showNotifications: showNotifications) else {
             return
         }
+        let presentationSessionIdentifier = UUID()
 
         ApiRequest.getMergedProxyData(session: session, timeout: 10) { [weak self] resp in
             DispatchQueue.main.async {
@@ -3888,17 +3889,39 @@ extension AppDelegate {
                     in: resp,
                     benchmarkURL: benchmarkURL,
                     timeout: timeout,
-                    session: session
-                ) { [weak self] in
-                    DispatchQueue.main.async {
-                        guard let self,
-                              self.isActiveBenchmarkSession(session) else { return }
-                        self.finishSpeedTest(
-                            session: session,
-                            showNotifications: showNotifications
-                        )
+                    session: session,
+                    result: { [weak self] result in
+                        DispatchQueue.main.async {
+                            guard let self,
+                                  !session.isCancelled,
+                                  self.isActiveBenchmarkSession(session) else { return }
+                            let state: ProxyBenchmarkRowState = result.delay > 0
+                                ? .measured(
+                                    displayName: result.identity.proxyName,
+                                    delay: result.delay
+                                )
+                                : .failed(displayName: result.identity.proxyName)
+                            GlobalLeafBenchmarkPresentationStore.publish(
+                                GlobalLeafBenchmarkPresentation(
+                                    identity: result.identity,
+                                    benchmarkURL: result.benchmarkURL,
+                                    sessionIdentifier: presentationSessionIdentifier,
+                                    rowState: state
+                                )
+                            )
+                        }
+                    },
+                    completion: { [weak self] in
+                        DispatchQueue.main.async {
+                            guard let self,
+                                  self.isActiveBenchmarkSession(session) else { return }
+                            self.finishSpeedTest(
+                                session: session,
+                                showNotifications: showNotifications
+                            )
+                        }
                     }
-                }
+                )
             }
         }
     }

--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -159,13 +159,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var isWakeEnhancedModeRestarting = false
     private var enhancedModeHealthTimer: Timer?
     private var isEnhancedModeHealthCheckInFlight = false
+    private var isCoreCPUStatusCheckInFlight = false
+    private var coreCPUStatusRequestGeneration = 0
+    private var coreCPUWatchdogPolicy = CoreCPUWatchdogPolicy()
+    private var latestTrafficBytesPerSecond = 0
+    private var latestTrafficUpdateTime = Date.distantPast
     private var consecutiveEnhancedModeHealthFailures = 0
     private var consecutiveEnhancedModeDataPlaneFailures = 0
     private var enhancedModeHealthGraceUntil = Date.distantPast
     private var lastEnhancedModeDataPlaneProbeAt = Date.distantPast
     private var lastEnhancedModeDataPlaneRecoveryTime = Date.distantPast
+    private var lastCoreCPURecoveryTime = Date.distantPast
     private var isEnhancedModeRuntimeRecoveryPending = false
     private(set) var enhancedModeRuntimeHealthSummary = "not checked"
+    private(set) var coreCPUWatchdogSummary = "not checked"
     private(set) var wakeRecoveryDiagnosticSummary = "idle"
     private var lastCoreLogRecoveryTime = Date.distantPast
     private var didCompleteStaleEnhancedCoreCleanup = false
@@ -197,6 +204,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private static let enhancedModeDataPlaneProbeRequestTimeout: TimeInterval = 8
     private static let enhancedModeDataPlaneFailureThreshold = 3
     private static let enhancedModeDataPlaneRecoveryCooldown: TimeInterval = 10 * 60
+    private static let coreCPURecoveryCooldown: TimeInterval = 30 * 60
+    private static let coreCPUActiveTrafficThreshold = 64 * 1024
+    private static let coreCPUActiveTrafficFreshness: TimeInterval = 30
     /// Literal-IP endpoints keep the system-direct baseline independent from
     /// Mihomo DNS. Each endpoint is tested through core DIRECT first and, only
     /// on failure, through ClashFX Networking's generated DIRECT exemption.
@@ -1611,6 +1621,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard Settings.enhancedMode,
               ConfigManager.shared.isEnhancedModeActive,
               enhancedModeMenuItem.isEnabled else {
+            coreCPUWatchdogPolicy.reset()
+            coreCPUWatchdogSummary = Settings.enhancedMode
+                ? "enabled preference; runtime not active"
+                : "inactive"
             consecutiveEnhancedModeHealthFailures = 0
             consecutiveEnhancedModeDataPlaneFailures = 0
             enhancedModeRuntimeHealthSummary = Settings.enhancedMode
@@ -1621,10 +1635,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard !isWakeEnhancedModeRestarting,
               !isEnhancedModeRuntimeRecoveryPending else { return }
         guard Date() >= enhancedModeHealthGraceUntil else {
+            coreCPUWatchdogPolicy.reset()
+            coreCPUWatchdogSummary = "startup grace period"
             consecutiveEnhancedModeHealthFailures = 0
             consecutiveEnhancedModeDataPlaneFailures = 0
             return
         }
+        checkEnhancedModeCoreCPU()
         guard !isEnhancedModeHealthCheckInFlight else { return }
 
         isEnhancedModeHealthCheckInFlight = true
@@ -1678,6 +1695,159 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                         "\(Self.enhancedModeHealthFailureThreshold) checks: \(reason)"
                 )
             }
+        }
+    }
+
+    private func checkEnhancedModeCoreCPU() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard !isCoreCPUStatusCheckInFlight else { return }
+        guard !isSpeedTesting, !isConfigUpdating else {
+            coreCPUWatchdogPolicy.reset()
+            coreCPUWatchdogSummary = "paused during benchmark or configuration update"
+            return
+        }
+        let trafficAge = Date().timeIntervalSince(latestTrafficUpdateTime)
+        guard trafficAge < 0 ||
+            trafficAge > Self.coreCPUActiveTrafficFreshness ||
+            latestTrafficBytesPerSecond < Self.coreCPUActiveTrafficThreshold else {
+            coreCPUWatchdogPolicy.reset()
+            coreCPUWatchdogSummary =
+                "paused during active traffic: \(latestTrafficBytesPerSecond) B/s"
+            return
+        }
+        guard let helper = PrivilegedHelperManager.shared.helper() else {
+            coreCPUWatchdogPolicy.reset()
+            coreCPUWatchdogSummary = "helper unavailable"
+            return
+        }
+
+        isCoreCPUStatusCheckInFlight = true
+        coreCPUStatusRequestGeneration += 1
+        let requestGeneration = coreCPUStatusRequestGeneration
+        let invocation: Void? = helper.getMihomoCoreStatus? { [weak self] optionalStatus in
+            DispatchQueue.main.async {
+                guard let self = self,
+                      requestGeneration == self.coreCPUStatusRequestGeneration else { return }
+                self.isCoreCPUStatusCheckInFlight = false
+                guard Settings.enhancedMode,
+                      ConfigManager.shared.isEnhancedModeActive,
+                      self.enhancedModeMenuItem.isEnabled,
+                      !self.isWakeEnhancedModeRestarting,
+                      !self.isEnhancedModeRuntimeRecoveryPending else {
+                    self.coreCPUWatchdogPolicy.reset()
+                    return
+                }
+
+                let status = optionalStatus ?? [:]
+                guard (status["running"] as? NSNumber)?.boolValue == true,
+                      let launchID = status["launchID"] as? String,
+                      let processIdentifier = (status["pid"] as? NSNumber)?.intValue,
+                      let cpuTimeNanoseconds = (status["cpuTimeNanoseconds"] as? NSNumber)?.doubleValue,
+                      let sampleUptime = (status["sampleUptime"] as? NSNumber)?.doubleValue else {
+                    self.coreCPUWatchdogPolicy.reset()
+                    self.coreCPUWatchdogSummary = status["cpuSampleError"] as? String
+                        ?? "CPU telemetry unavailable"
+                    return
+                }
+
+                let sample = CoreCPUWatchdogSample(
+                    launchID: launchID,
+                    processIdentifier: processIdentifier,
+                    cpuTime: cpuTimeNanoseconds / 1_000_000_000,
+                    sampleUptime: sampleUptime
+                )
+                self.handleCoreCPUWatchdogDecision(
+                    self.coreCPUWatchdogPolicy.observe(sample),
+                    sample: sample
+                )
+            }
+        }
+        if invocation == nil {
+            coreCPUStatusRequestGeneration += 1
+            isCoreCPUStatusCheckInFlight = false
+            coreCPUWatchdogPolicy.reset()
+            coreCPUWatchdogSummary = "installed helper lacks CPU telemetry"
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.enhancedModeHelperRequestTimeout
+        ) { [weak self] in
+            guard let self = self,
+                  self.isCoreCPUStatusCheckInFlight,
+                  requestGeneration == self.coreCPUStatusRequestGeneration else { return }
+            self.coreCPUStatusRequestGeneration += 1
+            self.isCoreCPUStatusCheckInFlight = false
+            self.coreCPUWatchdogPolicy.reset()
+            self.coreCPUWatchdogSummary = "helper CPU telemetry timed out"
+            Logger.log(
+                "Enhanced Mode core CPU telemetry timed out",
+                level: .warning
+            )
+        }
+    }
+
+    private func handleCoreCPUWatchdogDecision(
+        _ decision: CoreCPUWatchdogDecision,
+        sample: CoreCPUWatchdogSample
+    ) {
+        dispatchPrecondition(condition: .onQueue(.main))
+
+        func percentage(_ utilization: Double) -> Int {
+            Int((utilization * 100).rounded())
+        }
+
+        switch decision {
+        case .invalid:
+            coreCPUWatchdogSummary = "invalid CPU telemetry"
+        case .baseline:
+            coreCPUWatchdogSummary = "baseline pid=\(sample.processIdentifier)"
+        case let .normal(utilization):
+            coreCPUWatchdogSummary = "normal: \(percentage(utilization))% of one core"
+        case let .elevated(utilization, consecutiveSamples):
+            coreCPUWatchdogSummary =
+                "elevated: \(percentage(utilization))% of one core " +
+                "for \(consecutiveSamples) sample(s)"
+            if consecutiveSamples == 1 {
+                Logger.log(
+                    "Enhanced Mode core CPU is elevated: \(coreCPUWatchdogSummary)",
+                    level: .warning
+                )
+            }
+        case let .captureDiagnostic(utilization, consecutiveSamples):
+            coreCPUWatchdogSummary =
+                "diagnostic capture: \(percentage(utilization))% of one core " +
+                "for \(consecutiveSamples) sample(s)"
+            Logger.log(
+                "Enhanced Mode core CPU remained elevated; capturing diagnostic: " +
+                    coreCPUWatchdogSummary,
+                level: .error
+            )
+            captureExternalCoreDiagnostic(reason: coreCPUWatchdogSummary) {}
+        case let .recover(utilization, consecutiveSamples):
+            let reason =
+                "sustained core CPU: \(percentage(utilization))% of one core " +
+                "for \(consecutiveSamples) sample(s), pid=\(sample.processIdentifier), " +
+                "launch=\(sample.launchID)"
+            let now = Date()
+            guard now.timeIntervalSince(lastCoreCPURecoveryTime) >=
+                Self.coreCPURecoveryCooldown else {
+                coreCPUWatchdogSummary = "recovery cooldown active after \(reason)"
+                Logger.log(
+                    "Enhanced Mode core CPU remains elevated, but automatic recovery " +
+                        "is in cooldown: \(reason)",
+                    level: .warning
+                )
+                return
+            }
+
+            lastCoreCPURecoveryTime = now
+            coreCPUWatchdogSummary = "automatic recovery triggered: \(reason)"
+            Logger.log(
+                "Enhanced Mode core CPU remained elevated; rebuilding core: \(reason)",
+                level: .error
+            )
+            captureAndRestartEnhancedMode(reason: reason)
         }
     }
 
@@ -4147,6 +4317,9 @@ extension AppDelegate {
 
 extension AppDelegate: ApiRequestStreamDelegate {
     func didUpdateTraffic(up: Int, down: Int) {
+        let (trafficBytes, overflow) = max(0, up).addingReportingOverflow(max(0, down))
+        latestTrafficBytesPerSecond = overflow ? Int.max : trafficBytes
+        latestTrafficUpdateTime = Date()
         statusItemView.updateSpeedLabel(up: up, down: down)
     }
 

--- a/ClashFX/General/ApiRequest.swift
+++ b/ClashFX/General/ApiRequest.swift
@@ -92,6 +92,12 @@ class ApiRequest {
         let proxyName: ClashProxyName
     }
 
+    struct LeafProxyBenchmarkResult {
+        let identity: LeafProxyBenchmarkIdentity
+        let benchmarkURL: String
+        let delay: Int
+    }
+
     final class BenchmarkSession {
         private let lock = NSLock()
         private var requests: [UUID: DataRequest] = [:]
@@ -818,6 +824,7 @@ class ApiRequest {
                                      timeout: Int,
                                      maxConcurrent: Int = benchmarkMaxConcurrent,
                                      session: BenchmarkSession? = nil,
+                                     result: @escaping (LeafProxyBenchmarkResult) -> Void = { _ in },
                                      completion: @escaping () -> Void) {
         guard session?.isCancelled != true else {
             completion()
@@ -855,7 +862,16 @@ class ApiRequest {
                     benchmarkURL: benchmarkURL,
                     timeout: timeout,
                     session: session
-                ) { _ in
+                ) { delay in
+                    result(LeafProxyBenchmarkResult(
+                        identity: LeafProxyBenchmarkIdentity(
+                            endpoint: .inline,
+                            providerName: nil,
+                            proxyName: proxy.name
+                        ),
+                        benchmarkURL: benchmarkURL,
+                        delay: delay
+                    ))
                     done()
                 }
             }
@@ -883,7 +899,16 @@ class ApiRequest {
                         benchmarkURL: benchmarkURL,
                         timeout: timeout,
                         session: session
-                    ) { _ in
+                    ) { delay in
+                        result(LeafProxyBenchmarkResult(
+                            identity: LeafProxyBenchmarkIdentity(
+                                endpoint: .provider,
+                                providerName: provider.name,
+                                proxyName: proxy.name
+                            ),
+                            benchmarkURL: benchmarkURL,
+                            delay: delay
+                        ))
                         done()
                     }
                 }

--- a/ClashFX/General/Managers/LabSupport.swift
+++ b/ClashFX/General/Managers/LabSupport.swift
@@ -42,6 +42,7 @@ enum LabSupport {
         lines.append("- DNS Servers: \(NetworkChangeNotifier.getCurrentDns().joined(separator: ", "))")
         lines.append("- TUN Interfaces: \(tunInterfaceSummary())")
         lines.append("- Enhanced Runtime Health: \(AppDelegate.shared.enhancedModeRuntimeHealthSummary)")
+        lines.append("- Core CPU Watchdog: \(AppDelegate.shared.coreCPUWatchdogSummary)")
         lines.append("- Wake Recovery: \(AppDelegate.shared.wakeRecoveryDiagnosticSummary)")
         lines.append("")
         lines.append("### Recent log (last 50 lines, sensitive data redacted)")

--- a/ClashFX/General/Managers/MenuItemFactory.swift
+++ b/ClashFX/General/Managers/MenuItemFactory.swift
@@ -25,6 +25,7 @@ class MenuItemFactory {
 
     static func recreateProxyMenuItems() {
         let recreate = {
+            GlobalLeafBenchmarkPresentationStore.clearAll()
             AutomaticGroupBenchmarkPresentationStore.clearAll()
             AutomaticChildBenchmarkStore.clearAll()
             // Selector presentations reconcile against the new snapshot and are
@@ -71,6 +72,7 @@ class MenuItemFactory {
             return
         }
 
+        GlobalLeafBenchmarkPresentationStore.prune(using: info)
         AutomaticGroupBenchmarkPresentationStore.prune(using: info)
         AutomaticChildBenchmarkStore.prune(using: info)
         SelectorBenchmarkPresentationStore.prune(using: info)

--- a/ClashFX/General/Managers/StartupProxyRecoveryPolicy.swift
+++ b/ClashFX/General/Managers/StartupProxyRecoveryPolicy.swift
@@ -69,6 +69,119 @@ enum RuntimeDataPlaneFailurePolicy {
     }
 }
 
+struct CoreCPUWatchdogSample: Equatable {
+    let launchID: String
+    let processIdentifier: Int
+    let cpuTime: TimeInterval
+    let sampleUptime: TimeInterval
+}
+
+enum CoreCPUWatchdogDecision: Equatable {
+    case invalid
+    case baseline
+    case normal(utilization: Double)
+    case elevated(utilization: Double, consecutiveSamples: Int)
+    case captureDiagnostic(utilization: Double, consecutiveSamples: Int)
+    case recover(utilization: Double, consecutiveSamples: Int)
+}
+
+/// Detects a process consuming approximately one complete CPU core over a
+/// sustained period. Samples are tied to the helper launch identity and PID so
+/// delayed replies from an older core cannot accumulate toward recovery.
+struct CoreCPUWatchdogPolicy {
+    let utilizationThreshold: Double
+    let diagnosticSampleCount: Int
+    let recoverySampleCount: Int
+    let maximumSampleInterval: TimeInterval
+
+    private var previousSample: CoreCPUWatchdogSample?
+    private var consecutiveElevatedSamples = 0
+    private var didRequestDiagnostic = false
+
+    init(utilizationThreshold: Double = 0.90,
+         diagnosticSampleCount: Int = 8,
+         recoverySampleCount: Int = 12,
+         maximumSampleInterval: TimeInterval = 45) {
+        let validatedDiagnosticSampleCount = max(1, diagnosticSampleCount)
+        self.utilizationThreshold = utilizationThreshold
+        self.diagnosticSampleCount = validatedDiagnosticSampleCount
+        self.recoverySampleCount = max(
+            validatedDiagnosticSampleCount + 1,
+            recoverySampleCount
+        )
+        self.maximumSampleInterval = maximumSampleInterval
+    }
+
+    mutating func reset() {
+        previousSample = nil
+        consecutiveElevatedSamples = 0
+        didRequestDiagnostic = false
+    }
+
+    mutating func observe(_ sample: CoreCPUWatchdogSample) -> CoreCPUWatchdogDecision {
+        guard sample.processIdentifier > 0,
+              !sample.launchID.isEmpty,
+              sample.cpuTime.isFinite,
+              sample.sampleUptime.isFinite,
+              sample.cpuTime >= 0,
+              sample.sampleUptime >= 0 else {
+            reset()
+            return .invalid
+        }
+
+        guard let previousSample,
+              previousSample.launchID == sample.launchID,
+              previousSample.processIdentifier == sample.processIdentifier else {
+            reset()
+            previousSample = sample
+            return .baseline
+        }
+
+        let elapsed = sample.sampleUptime - previousSample.sampleUptime
+        let consumedCPU = sample.cpuTime - previousSample.cpuTime
+        self.previousSample = sample
+        guard elapsed > 0,
+              elapsed <= maximumSampleInterval,
+              consumedCPU >= 0,
+              consumedCPU.isFinite else {
+            consecutiveElevatedSamples = 0
+            didRequestDiagnostic = false
+            return .baseline
+        }
+
+        let utilization = consumedCPU / elapsed
+        guard utilization.isFinite, utilization >= 0 else {
+            reset()
+            return .invalid
+        }
+        guard utilization >= utilizationThreshold else {
+            consecutiveElevatedSamples = 0
+            didRequestDiagnostic = false
+            return .normal(utilization: utilization)
+        }
+
+        consecutiveElevatedSamples += 1
+        if consecutiveElevatedSamples >= recoverySampleCount {
+            let count = consecutiveElevatedSamples
+            consecutiveElevatedSamples = 0
+            didRequestDiagnostic = false
+            return .recover(utilization: utilization, consecutiveSamples: count)
+        }
+        if consecutiveElevatedSamples >= diagnosticSampleCount,
+           !didRequestDiagnostic {
+            didRequestDiagnostic = true
+            return .captureDiagnostic(
+                utilization: utilization,
+                consecutiveSamples: consecutiveElevatedSamples
+            )
+        }
+        return .elevated(
+            utilization: utilization,
+            consecutiveSamples: consecutiveElevatedSamples
+        )
+    }
+}
+
 enum WakeRecoveryRetryPolicy {
     static func delay(
         baseDelay: TimeInterval,

--- a/ClashFX/Models/ClashProxy.swift
+++ b/ClashFX/Models/ClashProxy.swift
@@ -285,6 +285,68 @@ enum ProxyBenchmarkRowState {
     }
 }
 
+struct LeafProxyBenchmarkIdentity: Hashable {
+    let endpoint: SelectorBenchmarkEndpoint
+    let providerName: ClashProviderName?
+    let proxyName: ClashProxyName
+
+    init(endpoint: SelectorBenchmarkEndpoint,
+         providerName: ClashProviderName?,
+         proxyName: ClashProxyName) {
+        self.endpoint = endpoint
+        self.providerName = providerName
+        self.proxyName = proxyName
+    }
+
+    init(proxy: ClashProxy) {
+        endpoint = proxy.enclosingProvider == nil ? .inline : .provider
+        providerName = proxy.enclosingProvider?.name
+        proxyName = proxy.name
+    }
+}
+
+struct GlobalLeafBenchmarkPresentation {
+    private static let freshCacheAge: TimeInterval = 30 * 60
+    private static let maximumCacheAge: TimeInterval = 24 * 60 * 60
+
+    let identity: LeafProxyBenchmarkIdentity
+    let benchmarkURL: String
+    let sessionIdentifier: UUID
+    let rowState: ProxyBenchmarkRowState
+    let publishedAt: Date
+
+    var isStale: Bool {
+        Date().timeIntervalSince(publishedAt) > Self.freshCacheAge
+    }
+
+    init(identity: LeafProxyBenchmarkIdentity,
+         benchmarkURL: String,
+         sessionIdentifier: UUID,
+         rowState: ProxyBenchmarkRowState,
+         publishedAt: Date = .init()) {
+        self.identity = identity
+        self.benchmarkURL = benchmarkURL
+        self.sessionIdentifier = sessionIdentifier
+        self.rowState = rowState
+        self.publishedAt = publishedAt
+    }
+
+    func reconciled(with proxy: ClashProxy,
+                    now: Date = .init()) -> GlobalLeafBenchmarkPresentation? {
+        guard now.timeIntervalSince(publishedAt) <= Self.maximumCacheAge,
+              proxy.all == nil,
+              identity == LeafProxyBenchmarkIdentity(proxy: proxy) else {
+            return nil
+        }
+        return self
+    }
+
+    func isNewer(than state: ClashProxyTestState?) -> Bool {
+        guard let latestHistory = state?.history.last else { return true }
+        return publishedAt >= latestHistory.time
+    }
+}
+
 struct SelectorBenchmarkPresentation {
     private static let freshCacheAge: TimeInterval = 30 * 60
     private static let maximumCacheAge: TimeInterval = 24 * 60 * 60

--- a/ClashFX/Resources/DashboardCompatibility/clashfx-compat.js
+++ b/ClashFX/Resources/DashboardCompatibility/clashfx-compat.js
@@ -1,8 +1,27 @@
 (function () {
   'use strict';
 
-  if (window.__CLASHFX_DASHBOARD_COMPAT__) return;
-  window.__CLASHFX_DASHBOARD_COMPAT__ = true;
+  var COMPATIBILITY_REVISION = '2026.09.07.1';
+  var existingDiagnostics = window.__CLASHFX_DASHBOARD_COMPAT__;
+  if (existingDiagnostics && existingDiagnostics.revision) return;
+
+  var diagnostics = {
+    revision: COMPATIBILITY_REVISION,
+    syntaxSupport: false,
+    renderedProbe: false,
+    expectedProbe: { red: 64, green: 128, blue: 192, alpha: 0.5 },
+    observedProbe: null,
+    fallbackInstalled: false,
+    themeProbe: {
+      startMs: null,
+      endMs: null,
+      count: 0,
+      durationMs: null,
+      totalCount: 0,
+      batches: 0
+    }
+  };
+  window.__CLASHFX_DASHBOARD_COMPAT__ = diagnostics;
 
   var themePalette = {
     light: { base: '#fff', primary: '#422ad5', content: '#18181b' },
@@ -42,9 +61,33 @@
     silk: { base: '#f7f5f3', primary: '#1c1c29', content: '#4b4743' }
   };
 
-  // MetaCubeXD used to synchronously force style calculation for every theme
-  // whenever the picker opened. Return its build-time palette without layout.
+  // MetaCubeXD synchronously asks for three colors for every hidden theme
+  // preview. Return its build-time palette without a layout round-trip.
   var nativeGetComputedStyle = window.getComputedStyle.bind(window);
+  var themeProbeTimer = null;
+  var activeThemeProbeStart = null;
+  var activeThemeProbeCount = 0;
+
+  function recordThemeProbe() {
+    var now = Date.now();
+    if (activeThemeProbeCount === 0) activeThemeProbeStart = now;
+    activeThemeProbeCount += 1;
+
+    if (themeProbeTimer) window.clearTimeout(themeProbeTimer);
+    themeProbeTimer = window.setTimeout(function () {
+      var end = Date.now();
+      diagnostics.themeProbe.startMs = activeThemeProbeStart;
+      diagnostics.themeProbe.endMs = end;
+      diagnostics.themeProbe.count = activeThemeProbeCount;
+      diagnostics.themeProbe.durationMs = Math.max(0, end - activeThemeProbeStart);
+      diagnostics.themeProbe.totalCount += activeThemeProbeCount;
+      diagnostics.themeProbe.batches += 1;
+      activeThemeProbeStart = null;
+      activeThemeProbeCount = 0;
+      themeProbeTimer = null;
+    }, 0);
+  }
+
   window.getComputedStyle = function (element, pseudoElement) {
     var themeName = element && element.getAttribute && element.getAttribute('data-theme');
     var palette = themeName && themePalette[themeName];
@@ -52,6 +95,7 @@
       element.style.position === 'absolute' && element.style.visibility === 'hidden' &&
       element.style.pointerEvents === 'none';
     if (isThemeProbe) {
+      recordThemeProbe();
       return {
         getPropertyValue: function (propertyName) {
           if (propertyName === '--color-base-100') return palette.base;
@@ -64,13 +108,73 @@
     return nativeGetComputedStyle(element, pseudoElement);
   };
 
-  var supportsColorMix = window.CSS && window.CSS.supports &&
-    window.CSS.supports('color', 'color-mix(in oklab, currentColor 50%, transparent)');
-  if (supportsColorMix) return;
+  diagnostics.syntaxSupport = !!(window.CSS && window.CSS.supports &&
+    window.CSS.supports('color', 'color-mix(in srgb, currentColor 50%, transparent)'));
+
+  function parseRenderedColor(value) {
+    if (!value || typeof value !== 'string') return null;
+    var rgba = value.match(/^rgba\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*\)$/i);
+    if (rgba) {
+      return {
+        red: Number(rgba[1]),
+        green: Number(rgba[2]),
+        blue: Number(rgba[3]),
+        alpha: Number(rgba[4]),
+        serialization: 'rgba'
+      };
+    }
+    var srgb = value.match(/^color\(\s*srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s*\/\s*([\d.]+)\s*\)$/i);
+    if (srgb) {
+      return {
+        red: Number(srgb[1]) * 255,
+        green: Number(srgb[2]) * 255,
+        blue: Number(srgb[3]) * 255,
+        alpha: Number(srgb[4]),
+        serialization: 'color(srgb)'
+      };
+    }
+    return null;
+  }
+
+  function supportsRenderedColorMix() {
+    var root = document.documentElement || document.body;
+    if (!root) return false;
+
+    var container = document.createElement('span');
+    var probe = document.createElement('span');
+    container.setAttribute('aria-hidden', 'true');
+    container.style.position = 'absolute';
+    container.style.left = '-9999px';
+    container.style.visibility = 'hidden';
+    container.style.pointerEvents = 'none';
+    probe.style.color = 'rgb(64, 128, 192)';
+    container.appendChild(probe);
+    root.appendChild(container);
+
+    var observed = null;
+    try {
+      // Assign after mounting so WebKit must resolve currentColor in a real tree.
+      probe.style.backgroundColor = 'color-mix(in srgb, currentColor 50%, transparent)';
+      observed = parseRenderedColor(nativeGetComputedStyle(probe).backgroundColor || '');
+      diagnostics.observedProbe = observed;
+    } catch (_) {
+      diagnostics.observedProbe = null;
+    }
+    if (container.parentNode) container.parentNode.removeChild(container);
+
+    if (!observed) return false;
+    var expected = diagnostics.expectedProbe;
+    return Math.abs(observed.red - expected.red) <= 1 &&
+      Math.abs(observed.green - expected.green) <= 1 &&
+      Math.abs(observed.blue - expected.blue) <= 1 &&
+      Math.abs(observed.alpha - expected.alpha) <= 0.02;
+  }
 
   function installLegacyColorFallbacks() {
     var root = document.documentElement;
     if (!root) return;
+
+    diagnostics.fallbackInstalled = true;
 
     var styleID = 'clashfx-legacy-color-fallbacks';
     var utilityClasses = {};
@@ -189,9 +293,14 @@
     });
   }
 
+  function activateCompatibility() {
+    diagnostics.renderedProbe = supportsRenderedColorMix();
+    if (!diagnostics.renderedProbe) installLegacyColorFallbacks();
+  }
+
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', installLegacyColorFallbacks);
+    document.addEventListener('DOMContentLoaded', activateCompatibility);
   } else {
-    installLegacyColorFallbacks();
+    activateCompatibility();
   }
 })();

--- a/ClashFX/ViewControllers/ClashWebViewContoller.swift
+++ b/ClashFX/ViewControllers/ClashWebViewContoller.swift
@@ -36,7 +36,16 @@ enum WebCacheCleaner {
 }
 
 class ClashWebViewContoller: NSViewController {
-    let webview: CustomWKWebView = .init()
+    let webview: CustomWKWebView = {
+        let configuration = WKWebViewConfiguration()
+        // `customUserAgent` replaces the complete WebKit UA, which removes the
+        // Safari/WebKit version diagnostics needed for legacy compatibility.
+        // This configuration property appends an app identifier while retaining
+        // the system-provided, version-bearing User-Agent string.
+        configuration.applicationNameForUserAgent = "ClashFX Runtime"
+        return CustomWKWebView(frame: .zero, configuration: configuration)
+    }()
+
     var bridge: JSBridge?
     let disposeBag = DisposeBag()
     let minSize = NSSize(width: 920, height: 580)
@@ -406,7 +415,6 @@ class ClashWebViewContoller: NSViewController {
         webview.uiDelegate = self
         webview.navigationDelegate = self
 
-        webview.customUserAgent = "ClashFX Runtime"
         if #available(macOS 13.3, *) {
             webview.isInspectable = true
         }

--- a/ClashFX/ViewControllers/ClashWebViewContoller.swift
+++ b/ClashFX/ViewControllers/ClashWebViewContoller.swift
@@ -47,7 +47,7 @@ class ClashWebViewContoller: NSViewController {
         guard let scriptURL = Bundle.main.url(
             forResource: "clashfx-compat",
             withExtension: "js",
-            subdirectory: "dashboard"
+            subdirectory: "DashboardCompatibility"
         ) else {
             Logger.log("[dashboard] compatibility script missing", level: .warning)
             return nil
@@ -98,6 +98,48 @@ class ClashWebViewContoller: NSViewController {
         }
         return origSend.apply(this, arguments);
       };
+    })();
+    """
+
+    private static let dashboardCompatibilityDiagnosticsJS: String = """
+    (function() {
+      var compatibility = window.__CLASHFX_DASHBOARD_COMPAT__;
+      if (!compatibility || typeof compatibility !== 'object') return null;
+      function number(value) {
+        return typeof value === 'number' && isFinite(value) ? Math.max(-9000000000000000, Math.min(9000000000000000, value)) : null;
+      }
+      function probe(value) {
+        if (!value || typeof value !== 'object') return null;
+        return {
+          red: number(value.red), green: number(value.green), blue: number(value.blue),
+          alpha: number(value.alpha), serialization: String(value.serialization || '').slice(0, 32)
+        };
+      }
+      var ua = String(navigator.userAgent || '').slice(0, 512);
+      var safari = ua.match(/Version\\/(\\d+(?:\\.\\d+){0,2}).*Safari\\//i);
+      var webKit = ua.match(/AppleWebKit\\/(\\d+(?:\\.\\d+){0,4})/i);
+      return JSON.stringify({
+        compatibility: {
+          revision: String(compatibility.revision || '').slice(0, 64),
+          syntaxSupport: compatibility.syntaxSupport === true,
+          renderedProbe: compatibility.renderedProbe === true,
+          expectedProbe: probe(compatibility.expectedProbe),
+          observedProbe: probe(compatibility.observedProbe),
+          fallbackInstalled: compatibility.fallbackInstalled === true,
+          themeProbe: compatibility.themeProbe ? {
+            startMs: number(compatibility.themeProbe.startMs),
+            endMs: number(compatibility.themeProbe.endMs),
+            count: number(compatibility.themeProbe.count),
+            durationMs: number(compatibility.themeProbe.durationMs),
+            totalCount: number(compatibility.themeProbe.totalCount),
+            batches: number(compatibility.themeProbe.batches)
+          } : null
+        },
+        safariVersion: safari ? safari[1] : null,
+        webKitVersion: webKit ? webKit[1] : null,
+        normalizedBrowserVersion: safari ? 'Safari ' + safari[1] + (webKit ? ' / WebKit ' + webKit[1] : '') : (webKit ? 'WebKit ' + webKit[1] : null),
+        userAgent: ua
+      });
     })();
     """
 
@@ -487,6 +529,17 @@ extension ClashWebViewContoller: WKUIDelegate, WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         Logger.log("[dashboard] didFinish \(String(describing: navigation))", level: .info)
+        webView.evaluateJavaScript(Self.dashboardCompatibilityDiagnosticsJS) { result, error in
+            if let error = error {
+                Logger.log("[dashboard] compatibility diagnostics unavailable: \(error)", level: .warning)
+                return
+            }
+            guard let diagnostics = result as? String, diagnostics.utf8.count <= 2048 else {
+                Logger.log("[dashboard] compatibility diagnostics unavailable", level: .warning)
+                return
+            }
+            Logger.log("[dashboard] compatibility diagnostics \(diagnostics)", level: .info)
+        }
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {

--- a/ClashFX/Views/ProxyMenuItem.swift
+++ b/ClashFX/Views/ProxyMenuItem.swift
@@ -8,6 +8,43 @@
 
 import Cocoa
 
+enum GlobalLeafBenchmarkPresentationStore {
+    private static var presentations = [LeafProxyBenchmarkIdentity: GlobalLeafBenchmarkPresentation]()
+
+    static func publish(_ presentation: GlobalLeafBenchmarkPresentation) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        presentations[presentation.identity] = presentation
+        NotificationCenter.default.post(
+            name: .speedTestFinishForProxy,
+            object: presentation
+        )
+    }
+
+    static func presentation(for proxy: ClashProxy) -> GlobalLeafBenchmarkPresentation? {
+        dispatchPrecondition(condition: .onQueue(.main))
+        let identity = LeafProxyBenchmarkIdentity(proxy: proxy)
+        guard let current = presentations[identity] else { return nil }
+        guard let reconciled = current.reconciled(with: proxy) else {
+            presentations[identity] = nil
+            return nil
+        }
+        return reconciled
+    }
+
+    static func prune(using snapshot: ClashProxyResp) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        let validIdentities = Set(snapshot.proxies.compactMap { proxy -> LeafProxyBenchmarkIdentity? in
+            proxy.all == nil ? LeafProxyBenchmarkIdentity(proxy: proxy) : nil
+        })
+        presentations = presentations.filter { validIdentities.contains($0.key) }
+    }
+
+    static func clearAll() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        presentations.removeAll()
+    }
+}
+
 enum SelectorBenchmarkPresentationStore {
     private struct Key: Hashable {
         let selectorName: ClashProxyName
@@ -192,6 +229,7 @@ class ProxyMenuItem: NSMenuItem {
     private let parentGroupName: ClashProxyName
     private let parentGroupType: ClashProxyType
     private let parentConfiguredBenchmarkURL: String?
+    private let benchmarkIdentity: LeafProxyBenchmarkIdentity
     private var presentationName: String
     private var selectorBenchmarkPresentation: SelectorBenchmarkPresentation?
 
@@ -214,6 +252,7 @@ class ProxyMenuItem: NSMenuItem {
         proxyName = proxy.name
         parentGroupName = group.name
         parentGroupType = group.type
+        benchmarkIdentity = LeafProxyBenchmarkIdentity(proxy: proxy)
         parentConfiguredBenchmarkURL = group.testUrl.flatMap {
             let value = $0.trimmingCharacters(in: .whitespacesAndNewlines)
             return value.isEmpty ? nil : value
@@ -270,7 +309,13 @@ class ProxyMenuItem: NSMenuItem {
               presentation.rowName == proxyName else {
             guard let presentation = note.object as? AutomaticGroupChildBenchmarkPresentation,
                   presentation.identity.groupName == parentGroupName,
-                  presentation.rowName == proxyName else { return }
+                  presentation.rowName == proxyName else {
+                guard let presentation = note.object as? GlobalLeafBenchmarkPresentation,
+                      presentation.identity == benchmarkIdentity,
+                      parentGroupType == .select else { return }
+                applyGlobalLeafBenchmarkPresentation(presentation)
+                return
+            }
             applyAutomaticChildBenchmarkPresentation(presentation)
             return
         }
@@ -356,6 +401,21 @@ class ProxyMenuItem: NSMenuItem {
         applyStaleAppearance(presentation.isStale)
     }
 
+    private func applyGlobalLeafBenchmarkPresentation(
+        _ presentation: GlobalLeafBenchmarkPresentation
+    ) {
+        presentationName = proxyName
+        toolTip = presentation.benchmarkURL == parentBenchmarkURL
+            ? nil
+            : presentation.benchmarkURL
+        updatePresentation(
+            name: proxyName,
+            delay: presentation.rowState.delayDisplay,
+            rawValue: presentation.rowState.rawDelay
+        )
+        applyStaleAppearance(presentation.isStale)
+    }
+
     private func updateAutomaticChildBenchmarkPresentation(from info: ClashProxy) {
         guard let snapshot = info.enclosingResp,
               let group = snapshot.proxiesMap[parentGroupName] else {
@@ -399,6 +459,9 @@ class ProxyMenuItem: NSMenuItem {
             updatePresentation(name: proxyName, delay: nil, rawValue: nil)
             return
         }
+        let globalPresentation = info.all == nil
+            ? GlobalLeafBenchmarkPresentationStore.presentation(for: info)
+            : nil
 
         if let presentation = SelectorBenchmarkPresentationStore.presentation(
             selectorName: parentGroupName,
@@ -413,15 +476,33 @@ class ProxyMenuItem: NSMenuItem {
                     level: .warning
                 )
             }
-            applySelectorBenchmarkPresentation(presentation)
-            return
+            if case .unavailable = presentation.rowState {
+                selectorBenchmarkPresentation = nil
+            } else if let globalPresentation,
+                      globalPresentation.publishedAt > presentation.publishedAt {
+                selectorBenchmarkPresentation = nil
+                applyGlobalLeafBenchmarkPresentation(globalPresentation)
+                return
+            } else {
+                applySelectorBenchmarkPresentation(presentation)
+                return
+            }
         }
 
         selectorBenchmarkPresentation = nil
         presentationName = proxyName
         toolTip = nil
-        guard let leaf = finalLeaf(from: info),
-              let state = leaf.testState(for: parentBenchmarkURL),
+        guard let leaf = finalLeaf(from: info) else {
+            updatePresentation(name: proxyName, delay: nil, rawValue: nil)
+            return
+        }
+        let state = leaf.testState(for: parentBenchmarkURL)
+        if let globalPresentation,
+           globalPresentation.isNewer(than: state) {
+            applyGlobalLeafBenchmarkPresentation(globalPresentation)
+            return
+        }
+        guard let state,
               let history = state.history.last else {
             updatePresentation(name: proxyName, delay: nil, rawValue: nil)
             return

--- a/ClashFXTests/BenchmarkRegressionTests.swift
+++ b/ClashFXTests/BenchmarkRegressionTests.swift
@@ -1444,6 +1444,20 @@ final class SubscriptionStatusPresentationTests: XCTestCase {
 }
 
 final class StartupProxyRecoveryPolicyTests: XCTestCase {
+    private func cpuSample(
+        launchID: String = "launch-a",
+        processIdentifier: Int = 42,
+        cpuTime: TimeInterval,
+        uptime: TimeInterval
+    ) -> CoreCPUWatchdogSample {
+        CoreCPUWatchdogSample(
+            launchID: launchID,
+            processIdentifier: processIdentifier,
+            cpuTime: cpuTime,
+            sampleUptime: uptime
+        )
+    }
+
     private func observation(
         wantsSystemProxy: Bool = true,
         proxyPaused: Bool = false,
@@ -1531,6 +1545,86 @@ final class StartupProxyRecoveryPolicyTests: XCTestCase {
                 outcome: .confirmedCoreFailure
             ),
             3
+        )
+    }
+
+    func testCoreCPUWatchdogCapturesThenRecoversAfterSustainedSingleCoreLoad() {
+        var policy = CoreCPUWatchdogPolicy(
+            utilizationThreshold: 0.9,
+            diagnosticSampleCount: 2,
+            recoverySampleCount: 3,
+            maximumSampleInterval: 20
+        )
+
+        XCTAssertEqual(
+            policy.observe(cpuSample(cpuTime: 10, uptime: 100)),
+            .baseline
+        )
+        XCTAssertEqual(
+            policy.observe(cpuSample(cpuTime: 19.5, uptime: 110)),
+            .elevated(utilization: 0.95, consecutiveSamples: 1)
+        )
+        XCTAssertEqual(
+            policy.observe(cpuSample(cpuTime: 29, uptime: 120)),
+            .captureDiagnostic(utilization: 0.95, consecutiveSamples: 2)
+        )
+        XCTAssertEqual(
+            policy.observe(cpuSample(cpuTime: 38.5, uptime: 130)),
+            .recover(utilization: 0.95, consecutiveSamples: 3)
+        )
+    }
+
+    func testCoreCPUWatchdogResetsOnNormalLoadCoreReplacementAndLongGap() {
+        var policy = CoreCPUWatchdogPolicy(
+            utilizationThreshold: 0.9,
+            diagnosticSampleCount: 2,
+            recoverySampleCount: 3,
+            maximumSampleInterval: 20
+        )
+
+        XCTAssertEqual(policy.observe(cpuSample(cpuTime: 0, uptime: 0)), .baseline)
+        XCTAssertEqual(
+            policy.observe(cpuSample(cpuTime: 9.5, uptime: 10)),
+            .elevated(utilization: 0.95, consecutiveSamples: 1)
+        )
+        XCTAssertEqual(
+            policy.observe(cpuSample(cpuTime: 10.5, uptime: 20)),
+            .normal(utilization: 0.1)
+        )
+        XCTAssertEqual(
+            policy.observe(cpuSample(
+                launchID: "launch-b",
+                processIdentifier: 84,
+                cpuTime: 2,
+                uptime: 30
+            )),
+            .baseline
+        )
+        XCTAssertEqual(
+            policy.observe(cpuSample(
+                launchID: "launch-b",
+                processIdentifier: 84,
+                cpuTime: 40,
+                uptime: 70
+            )),
+            .baseline
+        )
+    }
+
+    func testCoreCPUWatchdogRejectsInvalidTelemetry() {
+        var policy = CoreCPUWatchdogPolicy()
+
+        XCTAssertEqual(
+            policy.observe(cpuSample(cpuTime: .infinity, uptime: 100)),
+            .invalid
+        )
+        XCTAssertEqual(
+            policy.observe(cpuSample(cpuTime: 1, uptime: -1)),
+            .invalid
+        )
+        XCTAssertEqual(
+            policy.observe(cpuSample(cpuTime: 1, uptime: 100)),
+            .baseline
         )
     }
 

--- a/ClashFXTests/BenchmarkRegressionTests.swift
+++ b/ClashFXTests/BenchmarkRegressionTests.swift
@@ -898,6 +898,100 @@ final class BenchmarkRegressionTests: XCTestCase {
         XCTAssertNil(proxy.testState(for: "https://unknown.example.test/generate_204"))
     }
 
+    func testGlobalLeafPresentationFillsSelectorURLGapAfterRefresh() throws {
+        let globalURL = "https://global.example.test/generate_204"
+        let selectorURL = "https://selector.example.test/generate_204"
+        let response = snapshot([
+            [
+                "name": "All Nodes",
+                "type": "Selector",
+                "all": ["Provider Node"],
+                "now": "Provider Node",
+                "history": [],
+                "testUrl": selectorURL
+            ],
+            [
+                "name": "Provider Node",
+                "type": "Vless",
+                "history": [],
+                "extra": [
+                    globalURL: [
+                        "alive": true,
+                        "history": [
+                            ["time": "2026-09-03T09:17:32.000+0000", "delay": 118]
+                        ]
+                    ]
+                ]
+            ]
+        ])
+        let proxy = try XCTUnwrap(response.proxiesMap["Provider Node"])
+        let publishedAt = Date(timeIntervalSince1970: 1_788_427_852)
+        let presentation = GlobalLeafBenchmarkPresentation(
+            identity: LeafProxyBenchmarkIdentity(proxy: proxy),
+            benchmarkURL: globalURL,
+            sessionIdentifier: UUID(),
+            rowState: .measured(displayName: proxy.name, delay: 118),
+            publishedAt: publishedAt
+        )
+
+        XCTAssertNil(proxy.testState(for: selectorURL))
+        XCTAssertEqual(
+            presentation.reconciled(
+                with: proxy,
+                now: publishedAt.addingTimeInterval(1)
+            )?.rowState.rawDelay,
+            118
+        )
+        XCTAssertTrue(presentation.isNewer(than: proxy.testState(for: selectorURL)))
+    }
+
+    func testGlobalLeafPresentationYieldsToNewerSelectorEvidenceAndRejectsWrongIdentity() throws {
+        let selectorURL = "https://selector.example.test/generate_204"
+        let response = snapshot([
+            [
+                "name": "Node",
+                "type": "Vless",
+                "history": [],
+                "extra": [
+                    selectorURL: [
+                        "alive": true,
+                        "history": [
+                            ["time": "2026-09-03T09:20:00.000+0000", "delay": 95]
+                        ]
+                    ]
+                ]
+            ]
+        ])
+        let proxy = try XCTUnwrap(response.proxiesMap["Node"])
+        let selectorState = try XCTUnwrap(proxy.testState(for: selectorURL))
+        let selectorMeasurementTime = try XCTUnwrap(selectorState.history.last?.time)
+        let presentation = GlobalLeafBenchmarkPresentation(
+            identity: LeafProxyBenchmarkIdentity(proxy: proxy),
+            benchmarkURL: "https://global.example.test/generate_204",
+            sessionIdentifier: UUID(),
+            rowState: .measured(displayName: proxy.name, delay: 118),
+            publishedAt: selectorMeasurementTime.addingTimeInterval(-1)
+        )
+
+        XCTAssertFalse(presentation.isNewer(than: selectorState))
+
+        let wrongProviderPresentation = GlobalLeafBenchmarkPresentation(
+            identity: LeafProxyBenchmarkIdentity(
+                endpoint: .provider,
+                providerName: "Different Provider",
+                proxyName: proxy.name
+            ),
+            benchmarkURL: selectorURL,
+            sessionIdentifier: UUID(),
+            rowState: .measured(displayName: proxy.name, delay: 72),
+            publishedAt: selectorMeasurementTime
+        )
+        XCTAssertNil(wrongProviderPresentation.reconciled(
+            with: proxy,
+            now: selectorMeasurementTime
+        ))
+    }
+
     func testEffectiveBenchmarkURLUsesExplicitNonEmptyValue() throws {
         let response = snapshot([
             [

--- a/ProxyConfigHelper/ProxyConfigHelper.m
+++ b/ProxyConfigHelper/ProxyConfigHelper.m
@@ -533,7 +533,8 @@ static BOOL RunTaskWithTimeout(NSString *executablePath,
     dispatch_async(dispatch_get_main_queue(), ^{
         NSTask *task = self.mihomoTask;
         NSMutableDictionary *status = [NSMutableDictionary dictionary];
-        status[@"running"] = @(task && task.isRunning);
+        BOOL running = task && task.isRunning;
+        status[@"running"] = @(running);
         status[@"pid"] = @(self.mihomoProcessID);
         if (self.mihomoLaunchID.length > 0) {
             status[@"launchID"] = self.mihomoLaunchID;
@@ -550,6 +551,22 @@ static BOOL RunTaskWithTimeout(NSString *executablePath,
         }
         if (self.mihomoLastTerminationSummary.length > 0) {
             status[@"lastTermination"] = self.mihomoLastTerminationSummary;
+        }
+        if (running && self.mihomoProcessID > 0) {
+            struct rusage_info_v2 usage = {0};
+            int result = proc_pid_rusage(
+                self.mihomoProcessID,
+                RUSAGE_INFO_V2,
+                (rusage_info_t *)&usage
+            );
+            status[@"sampleUptime"] = @(NSProcessInfo.processInfo.systemUptime);
+            if (result == 0) {
+                uint64_t cpuTimeNanoseconds = usage.ri_user_time + usage.ri_system_time;
+                status[@"cpuTimeNanoseconds"] = @(cpuTimeNanoseconds);
+            } else {
+                status[@"cpuSampleError"] = [NSString stringWithFormat:
+                    @"proc_pid_rusage failed: %s", strerror(errno)];
+            }
         }
         reply(status);
     });

--- a/ProxyConfigHelper/ProxyConfigRemoteProcessProtocol.h
+++ b/ProxyConfigHelper/ProxyConfigRemoteProcessProtocol.h
@@ -13,7 +13,7 @@ typedef void(^boolReplyBlock)(BOOL);
 typedef void(^dictReplyBlock)(NSDictionary *);
 typedef void(^uintReplyBlock)(NSUInteger);
 
-#define CLASHFX_HELPER_PROTOCOL_VERSION 3
+#define CLASHFX_HELPER_PROTOCOL_VERSION 4
 
 @protocol ProxyConfigRemoteProcessProtocol <NSObject>
 @required

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 - **Automatic-Group Leaf Delays Are Visible and Generation-Safe** — Automatic-group submenus now render URL-scoped delay badges for every direct candidate. Results carry group membership, benchmark URL, expected status, session identity, and expiry metadata, so provider changes and late callbacks cannot leave misleading group or leaf values behind. Mihomo's fresh `now` remains the only authority for the selected path. (#219)
 - **Dashboard Themes Persist and Legacy WebKit Renders Safely** — Opening or upgrading the dashboard now clears only volatile caches and preserves local storage, cookies, and IndexedDB. A capability-gated compatibility layer replaces unsupported `color-mix()` transparency on older WebKit and supplies cached theme preview colors without forcing layout for every theme. (#221, #223)
 - **Global Delay Results Remain Visible in Node Lists** — The top-level benchmark now retains each inline and provider leaf result with its test URL and session identity. Reopening a Selector keeps the newest applicable measurement even when that Selector uses a different configured test URL, while newer group-scoped evidence still wins. (#225)
+- **Runaway Enhanced-Mode Cores Are Captured and Recovered** — ClashFX now measures the managed Mihomo process's CPU time by launch identity and PID. Sustained near-single-core usage first saves a thread sample, then rebuilds Enhanced Mode if the condition continues, with startup grace, active-traffic suppression, and a recovery cooldown to avoid reacting to legitimate or short-lived work. The diagnostic report records the watchdog state. (#226)
 
 ---
 
@@ -13,6 +14,7 @@
 - **自动策略子节点延迟现在可见且不会串代** — 自动策略子菜单会为每个直接候选节点显示按该组 URL 测得的延迟。结果会携带成员列表、测速 URL、expected status、session 身份及过期信息，因此 provider 变化或旧回调不会留下误导性的策略组或节点数值；选中路径仍只以 Mihomo 最新 `now` 为准。 (#219)
 - **控制台主题可以持久保存，旧 WebKit 也能安全渲染** — 打开或升级控制台时只清理易失缓存，保留 local storage、Cookie 与 IndexedDB。能力检测兼容层会在旧 WebKit 上替代不支持的 `color-mix()` 透明效果，并使用缓存的主题预览色，避免为每个主题强制触发布局计算。 (#221, #223)
 - **全局测速结果会持续显示在节点列表中** — 顶部延迟测速现在会按节点来源、provider、测速 URL 和 session 保留每个叶子节点结果。即使 Selector 配置了不同测速地址，重新打开节点列表仍会显示最新适用结果；之后产生的分组测速证据仍会优先。 (#225)
+- **增强模式核心持续高占用时会先取证再恢复** — ClashFX 现在会按启动身份和 PID 计算受管 Mihomo 进程的 CPU 占用。接近单核满载持续一段时间后会先保存线程采样；异常继续存在时再重建增强模式，并通过启动宽限、活跃流量避让和恢复冷却避免响应正常或短时负载。诊断报告也会记录监测状态。 (#226)
 
 <!-- Previous release notes -->
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 - **Selected Automatic Results Arrive Before the Selector Retry Tail** — A selected automatic group is now retested first with its own URL and expected status, then published from Mihomo's fresh `now` before leaf rows begin. Selector concurrency grows only after complete launch cohorts settle, is capped at twelve, and retries at most four failed targets, preventing a long failure tail from hiding the result users asked for. (#147)
 - **Automatic-Group Leaf Delays Are Visible and Generation-Safe** — Automatic-group submenus now render URL-scoped delay badges for every direct candidate. Results carry group membership, benchmark URL, expected status, session identity, and expiry metadata, so provider changes and late callbacks cannot leave misleading group or leaf values behind. Mihomo's fresh `now` remains the only authority for the selected path. (#219)
 - **Dashboard Themes Persist and Legacy WebKit Renders Safely** — Opening or upgrading the dashboard now clears only volatile caches and preserves local storage, cookies, and IndexedDB. A capability-gated compatibility layer replaces unsupported `color-mix()` transparency on older WebKit and supplies cached theme preview colors without forcing layout for every theme. (#221, #223)
+- **Global Delay Results Remain Visible in Node Lists** — The top-level benchmark now retains each inline and provider leaf result with its test URL and session identity. Reopening a Selector keeps the newest applicable measurement even when that Selector uses a different configured test URL, while newer group-scoped evidence still wins. (#225)
 
 ---
 
@@ -11,6 +12,7 @@
 - **选中的自动策略会在 Selector 重试尾部之前返回** — 当前选中的自动策略会优先使用自身 URL 与 expected status 重测，并依据 Mihomo 最新 `now` 发布结果，随后才开始叶子节点测速。Selector 只会在完整启动批次结束后调整并发，上限降为 12，且最多重试 4 个失败目标，失败尾部不再长期遮住用户最关心的结果。 (#147)
 - **自动策略子节点延迟现在可见且不会串代** — 自动策略子菜单会为每个直接候选节点显示按该组 URL 测得的延迟。结果会携带成员列表、测速 URL、expected status、session 身份及过期信息，因此 provider 变化或旧回调不会留下误导性的策略组或节点数值；选中路径仍只以 Mihomo 最新 `now` 为准。 (#219)
 - **控制台主题可以持久保存，旧 WebKit 也能安全渲染** — 打开或升级控制台时只清理易失缓存，保留 local storage、Cookie 与 IndexedDB。能力检测兼容层会在旧 WebKit 上替代不支持的 `color-mix()` 透明效果，并使用缓存的主题预览色，避免为每个主题强制触发布局计算。 (#221, #223)
+- **全局测速结果会持续显示在节点列表中** — 顶部延迟测速现在会按节点来源、provider、测速 URL 和 session 保留每个叶子节点结果。即使 Selector 配置了不同测速地址，重新打开节点列表仍会显示最新适用结果；之后产生的分组测速证据仍会优先。 (#225)
 
 <!-- Previous release notes -->
 

--- a/install_dependency.sh
+++ b/install_dependency.sh
@@ -1,33 +1,72 @@
 #!/bin/bash
 set -e
+
+DASHBOARD_TAG="v1.266.1"
+DASHBOARD_COMMIT="3a880c5946b7c6f29f3886044afa85783557698a"
+DASHBOARD_SHA256="78c58e4411da4f9c493aa0a0ab35684c2681a9e197cb88d20d0f30878fbd8fe8"
+DASHBOARD_ARCHIVE_URL="https://github.com/MetaCubeX/metacubexd/releases/download/${DASHBOARD_TAG}/compressed-dist.tgz"
+
+REPOSITORY_ROOT="$(cd "$(dirname "$0")" && pwd)"
 echo "Build Clash core"
 
-cd ClashFX/goClash
+cd "$REPOSITORY_ROOT/ClashFX/goClash"
 python3 build_clash_universal.py
-cd ../..
+cd "$REPOSITORY_ROOT"
 
 echo "Pod install"
 bundle install --jobs 4
 bundle exec pod install
 echo "delete old files"
-rm -f ./ClashFX/Resources/Country.mmdb
-rm -rf ./ClashFX/Resources/dashboard
-rm -f GeoLite2-Country.*
+rm -f "$REPOSITORY_ROOT/ClashFX/Resources/Country.mmdb"
+rm -f "$REPOSITORY_ROOT"/GeoLite2-Country.*
 echo "install mmdb"
 curl -LO https://github.com/Dreamacro/maxmind-geoip/releases/latest/download/Country.mmdb
 gzip Country.mmdb
-mv Country.mmdb.gz ./ClashFX/Resources/Country.mmdb.gz
+mv Country.mmdb.gz "$REPOSITORY_ROOT/ClashFX/Resources/Country.mmdb.gz"
 echo "install dashboard"
-cd ClashFX/Resources
-if ! git clone --depth 1 -b gh-pages https://github.com/MetaCubeX/metacubexd.git dashboard 2>/dev/null; then
-    echo "Warning: Failed to clone dashboard, creating placeholder"
-    mkdir -p dashboard
-    echo "<html><body><h1>Dashboard not available</h1></body></html>" > dashboard/index.html
+DASHBOARD_DIR="$REPOSITORY_ROOT/ClashFX/Resources/dashboard"
+DASHBOARD_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/clashfx-dashboard.XXXXXX")"
+DASHBOARD_STAGE_DIR="$(mktemp -d "${DASHBOARD_DIR}.stage.XXXXXX")"
+DASHBOARD_BACKUP_DIR="${DASHBOARD_DIR}.previous.$$"
+
+cleanup_dashboard_temp() {
+    rm -rf "$DASHBOARD_TEMP_DIR" "$DASHBOARD_STAGE_DIR"
+}
+trap cleanup_dashboard_temp EXIT
+
+echo "download dashboard ${DASHBOARD_TAG} (${DASHBOARD_COMMIT})"
+curl --fail --location --retry 3 --output "$DASHBOARD_TEMP_DIR/compressed-dist.tgz" "$DASHBOARD_ARCHIVE_URL"
+ACTUAL_DASHBOARD_SHA256="$(shasum -a 256 "$DASHBOARD_TEMP_DIR/compressed-dist.tgz" | awk '{print $1}')"
+if [ "$ACTUAL_DASHBOARD_SHA256" != "$DASHBOARD_SHA256" ]; then
+    echo "Dashboard checksum mismatch for ${DASHBOARD_TAG}: expected ${DASHBOARD_SHA256}, got ${ACTUAL_DASHBOARD_SHA256}" >&2
+    exit 1
 fi
 
-if [ -d "dashboard/.git" ]; then
-    cd dashboard
-    rm -rf CNAME .git .nojekyll
-    cd ..
+tar -xzf "$DASHBOARD_TEMP_DIR/compressed-dist.tgz" -C "$DASHBOARD_STAGE_DIR"
+if [ ! -r "$DASHBOARD_STAGE_DIR/index.html" ]; then
+    echo "Dashboard archive has no static index.html" >&2
+    exit 1
 fi
-cd ../..
+if ! grep -q 'appVersion:"1.266.1"' "$DASHBOARD_STAGE_DIR/index.html"; then
+    echo "Dashboard archive does not contain expected version 1.266.1" >&2
+    exit 1
+fi
+
+if [ -e "$DASHBOARD_BACKUP_DIR" ]; then
+    echo "Dashboard backup path already exists: $DASHBOARD_BACKUP_DIR" >&2
+    exit 1
+fi
+if [ -e "$DASHBOARD_DIR" ]; then
+    mv "$DASHBOARD_DIR" "$DASHBOARD_BACKUP_DIR"
+fi
+if ! mv "$DASHBOARD_STAGE_DIR" "$DASHBOARD_DIR"; then
+    if [ -e "$DASHBOARD_BACKUP_DIR" ]; then
+        mv "$DASHBOARD_BACKUP_DIR" "$DASHBOARD_DIR"
+    fi
+    echo "Dashboard replacement failed" >&2
+    exit 1
+fi
+if [ -e "$DASHBOARD_BACKUP_DIR" ]; then
+    rm -rf "$DASHBOARD_BACKUP_DIR"
+fi
+echo "Installed MetaCubeXD dashboard ${DASHBOARD_TAG} (${DASHBOARD_COMMIT})"

--- a/scripts/verify-dashboard-compatibility-bundle.sh
+++ b/scripts/verify-dashboard-compatibility-bundle.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -eu
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 /path/to/ClashFX.app" >&2
+    exit 64
+fi
+
+APP_PATH="$1"
+RESOURCES_PATH="$APP_PATH/Contents/Resources"
+COMPATIBILITY_SCRIPT="$RESOURCES_PATH/DashboardCompatibility/clashfx-compat.js"
+DASHBOARD_INDEX="$RESOURCES_PATH/dashboard/index.html"
+
+if [ ! -r "$COMPATIBILITY_SCRIPT" ]; then
+    echo "Missing dashboard compatibility resource: $COMPATIBILITY_SCRIPT" >&2
+    exit 1
+fi
+if [ ! -r "$DASHBOARD_INDEX" ]; then
+    echo "Missing dashboard index: $DASHBOARD_INDEX" >&2
+    exit 1
+fi
+if ! grep -q '__CLASHFX_DASHBOARD_COMPAT__' "$COMPATIBILITY_SCRIPT"; then
+    echo "Dashboard compatibility diagnostic marker is missing" >&2
+    exit 1
+fi
+if ! grep -q 'appVersion:"1.266.1"' "$DASHBOARD_INDEX"; then
+    echo "Dashboard version marker 1.266.1 is missing" >&2
+    exit 1
+fi
+if grep -qi 'Dashboard not available' "$DASHBOARD_INDEX"; then
+    echo "Dashboard index is a placeholder" >&2
+    exit 1
+fi
+
+echo "Dashboard compatibility bundle verified: $APP_PATH"


### PR DESCRIPTION
## Summary

- keep Dashboard compatibility resources reproducible and independently packaged (#221)
- preserve global node benchmark results across Selector menus (#225)
- capture and recover sustained Enhanced Mode core CPU spin (#226)

## Verification

- 84 XCTest cases passed
- full ClashFX app and privileged helper build passed
- final Dashboard compatibility bundle checks are enforced in CI

Target release: Lab 1.1.10.9.