### PR TITLE
fix: prepare Lab 1.1.10.10 compatibility fixes

### DIFF
--- a/ClashFX.xcodeproj/project.pbxproj
+++ b/ClashFX.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+        D14700000000000000000001 /* SystemProxyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F935B2FB23085515009E4D33; };
+        D14700000000000000000002 /* SystemProxyManager+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = D14700000000000000000003; };
+        D14700000000000000000004 /* IsolatedOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D14700000000000000000005; };
 		C30100000000000000000003 /* BenchmarkRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30100000000000000000001 /* BenchmarkRegressionTests.swift */; };
 		C30100000000000000000013 /* ClashProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C9EF63223E78F5005D8B6A /* ClashProxy.swift */; };
 		C30100000000000000000014 /* ClashProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F939724B23A4B33500FE5A3F /* ClashProvider.swift */; };
@@ -213,6 +216,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+        D14700000000000000000003 /* SystemProxyManager+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemProxyManager+Live.swift"; sourceTree = "<group>"; };
+        D14700000000000000000005 /* IsolatedOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsolatedOperationTests.swift; sourceTree = "<group>"; };
 		C30100000000000000000001 /* BenchmarkRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkRegressionTests.swift; sourceTree = "<group>"; };
 		C30100000000000000000002 /* ClashFXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ClashFXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C30100000000000000000015 /* BenchmarkRegressionSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkRegressionSupport.swift; sourceTree = "<group>"; };
@@ -434,6 +439,7 @@
 			children = (
 				C30100000000000000000001 /* BenchmarkRegressionTests.swift */,
 				C30100000000000000000015 /* BenchmarkRegressionSupport.swift */,
+                D14700000000000000000005 /* IsolatedOperationTests.swift */,
 				C30800000000000000000001 /* ProxySettingRestorationPolicyTests.m */,
 			);
 			path = ClashFXTests;
@@ -510,6 +516,7 @@
 				495BFB8721919B9800C8779D /* RemoteConfigManager.swift */,
 				4952C3BE2115C7CA004A4FA8 /* MenuItemFactory.swift */,
 				F935B2FB23085515009E4D33 /* SystemProxyManager.swift */,
+                D14700000000000000000003 /* SystemProxyManager+Live.swift */,
 				F977FAAB2366790500C17F1F /* AutoUpgradeManager.swift */,
 				F977FAAD23669D6400C17F1F /* ConnectionManager.swift */,
 				F9E754CF239CC21F00CEE7CC /* WebPortalManager.swift */,
@@ -1093,6 +1100,8 @@
 				D22300000000000000000002 /* DashboardWebsiteDataPolicy.swift in Sources */,
 				C30100000000000000000003 /* BenchmarkRegressionTests.swift in Sources */,
 				C30100000000000000000016 /* BenchmarkRegressionSupport.swift in Sources */,
+                D14700000000000000000001 /* SystemProxyManager.swift in Sources */,
+                D14700000000000000000004 /* IsolatedOperationTests.swift in Sources */,
 				C30100000000000000000013 /* ClashProxy.swift in Sources */,
 				C30100000000000000000014 /* ClashProvider.swift in Sources */,
 				C30200000000000000000003 /* StartupProxyRecoveryPolicy.swift in Sources */,
@@ -1128,6 +1137,7 @@
 				495340B320DE68C300B0D3FF /* StatusItemView.swift in Sources */,
 				0DE4369C17354E28 /* SpeedTextView.swift in Sources */,
 				F935B2FC23085515009E4D33 /* SystemProxyManager.swift in Sources */,
+                D14700000000000000000002 /* SystemProxyManager+Live.swift in Sources */,
 				0AD7506D2A5B9B26001FFBBD /* ConnectionLeftTextCellView.swift in Sources */,
 				495A44D320D267D000888A0A /* LaunchAtLogin.swift in Sources */,
 				490C8A102AC26E67007140F2 /* JSBridge.swift in Sources */,

--- a/ClashFX/Actions/TerminalCleanUpAction.swift
+++ b/ClashFX/Actions/TerminalCleanUpAction.swift
@@ -12,6 +12,7 @@ import RxSwift
 
 enum TerminalConfirmAction {
     static func run() -> NSApplication.TerminateReply {
+        guard !AppDelegate.shared.isTerminating else { return .terminateLater }
         guard confirmAction() else {
             return .terminateCancel
         }
@@ -22,7 +23,9 @@ enum TerminalConfirmAction {
             currentSystemSetToClash: NetworkChangeNotifier.isCurrentSystemSetToClash(looser: true),
             hasInterfaceProxySetToClash: NetworkChangeNotifier.hasInterfaceProxySetToClash()
         ))
+        AppDelegate.shared.prepareForTerminationCleanup()
         let group = DispatchGroup()
+        var proxyCleanupSucceeded = !policy.cleanSystemProxy
 
         if policy.cleanEnhancedMode {
             Logger.log("ClashFX quit need clean Enhanced Mode")
@@ -36,7 +39,8 @@ enum TerminalConfirmAction {
             Logger.log("ClashFX quit need clean proxy setting")
             group.enter()
 
-            SystemProxyManager.shared.disableProxy(forceDisable: policy.forceDisableProxy) {
+            SystemProxyManager.shared.restoreForTermination { success in
+                proxyCleanupSucceeded = success
                 group.leave()
             }
         }
@@ -58,26 +62,28 @@ enum TerminalConfirmAction {
                 quittingMenu.addItem(quittingItem)
                 statusItem.menu = quittingMenu
             }
-            AppDelegate.shared.disposeBag = DisposeBag()
         }
 
-        let terminationSettlement = ManagedOperationSettlement<Void> { _ in
+        let terminationSettlement = ManagedOperationSettlement<Bool> { succeeded in
             DispatchQueue.main.async {
-                NSApp.reply(toApplicationShouldTerminate: true)
+                if !succeeded {
+                    AppDelegate.shared.cancelTerminationCleanup()
+                }
+                NSApp.reply(toApplicationShouldTerminate: succeeded)
+                if !succeeded {
+                    NSAlert.alert(with: NSLocalizedString(
+                        "Proxy cleanup failed. ClashFX remains open; please try quitting again.",
+                        comment: ""
+                    ))
+                }
             }
         }
-        terminationSettlement.scheduleTimeout(after: 10, queue: .global(qos: .default), outcome: { () })
-
-        DispatchQueue.global(qos: .default).async {
-            let res = group.wait(timeout: .now() + 9.8)
-            switch res {
-            case .success:
-                Logger.log("ClashFX quit after clean up finish")
-                _ = terminationSettlement.finish(())
-            case .timedOut:
-                Logger.log("ClashFX quit after clean up timeout")
-                _ = terminationSettlement.finish(())
-            }
+        // Include an in-flight capture/enable followed by restore and readback.
+        // These XPC stages each have their own eight-second deadline.
+        terminationSettlement.scheduleTimeout(after: 40, queue: .main, outcome: { false })
+        group.notify(queue: .main) {
+            Logger.log("ClashFX quit cleanup completed: proxy success=\(proxyCleanupSucceeded)")
+            _ = terminationSettlement.finish(proxyCleanupSucceeded)
         }
 
         Logger.log("ClashFX quit wait for clean up")

--- a/ClashFX/AppDelegate.swift
+++ b/ClashFX/AppDelegate.swift
@@ -401,6 +401,30 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return TerminalConfirmAction.run()
     }
 
+    private(set) var isTerminating = false
+
+    func prepareForTerminationCleanup() {
+        isTerminating = true
+        SystemProxyManager.shared.prepareForTermination()
+        cancelActiveSpeedTest(reason: "application quit", refreshMenu: false)
+        pendingStartupProxyRecoveryWork?.cancel()
+        pendingStartupProxyRecoveryWork = nil
+        isStartupProxyRecoveryActive = false
+        pendingWakeRecoveryWork?.cancel()
+        pendingWakeRecoveryWork = nil
+        wakeRecoveryGeneration += 1
+        enhancedModeHealthTimer?.invalidate()
+        enhancedModeHealthTimer = nil
+    }
+
+    func cancelTerminationCleanup() {
+        isTerminating = false
+        SystemProxyManager.shared.resumeAfterCancelledTermination()
+        statusItem.menu = statusMenu
+        startEnhancedModeHealthMonitor()
+        restoreEnhancedModeIfNeeded()
+    }
+
     func applicationWillTerminate(_ aNotification: Notification) {
         UserDefaults.standard.set(0, forKey: "launch_fail_times")
         Logger.log("ClashFX will terminate")
@@ -415,10 +439,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Fallback: TerminalCleanUpAction.run() already handles Enhanced Mode cleanup
         // in the normal quit path. This guard only fires if applicationWillTerminate
         // is reached without going through TerminalCleanUpAction (e.g. forced termination).
-        if ConfigManager.shared.isEnhancedModeActive, !isRestarting {
+        if ConfigManager.shared.isEnhancedModeActive, !isRestarting, !isTerminating {
             cleanupEnhancedModeForTermination {}
         }
-        if !isRestarting,
+        if !isRestarting, !isTerminating,
            NetworkChangeNotifier.isCurrentSystemSetToClash(looser: true) ||
            NetworkChangeNotifier.hasInterfaceProxySetToClash() {
             Logger.log("Need Reset Proxy Setting again", level: .error)
@@ -940,6 +964,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             .observe(on: MainScheduler.instance)
             .delay(.milliseconds(200), scheduler: MainScheduler.instance)
             .bind { [weak self] _ in
+                guard self?.isTerminating == false else { return }
                 guard NetworkChangeNotifier.getPrimaryInterface() != nil else { return }
                 let proxySetted = NetworkChangeNotifier.isCurrentSystemSetToClash()
                 if !proxySetted,
@@ -976,6 +1001,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             .filter { $0 != nil }
             .observe(on: MainScheduler.instance)
             .debounce(.seconds(5), scheduler: MainScheduler.instance).bind { [weak self] _ in
+                guard self?.isTerminating == false else { return }
                 if self?.isStartupProxyRecoveryActive == true {
                     self?.scheduleStartupProxyRecovery(after: 0.1)
                 }
@@ -1562,6 +1588,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func resetProxySettingOnWakeupFromSleep() {
+        guard !isTerminating else { return }
         Logger.log("Wake recovery: didWake received")
         recordWakeRecoveryBreadcrumb("didWake received", expectsProgressWithin: Self.wakeRecoveryDelay + 2)
 
@@ -1588,6 +1615,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func scheduleWakeRecovery() {
+        guard !isTerminating else { return }
         pendingWakeRecoveryWork?.cancel()
         wakeRecoveryGeneration += 1
         let generation = wakeRecoveryGeneration
@@ -2219,6 +2247,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func recoverFromCoreLogFailure(_ reason: CoreLogRecoveryReason) {
         let recover = { [weak self] in
             guard let self = self else { return }
+            guard !self.isTerminating else { return }
             guard Settings.enhancedMode,
                   ConfigManager.shared.isEnhancedModeActive,
                   self.enhancedModeMenuItem.isEnabled,
@@ -2590,8 +2619,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func healthCheckOnNetworkChange() {
-        ApiRequest.getMergedProxyData {
-            proxyResp in
+        guard !isTerminating else { return }
+        ApiRequest.getMergedProxyData { [weak self] proxyResp in
+            guard self?.isTerminating == false else { return }
             guard let proxyResp = proxyResp else { return }
 
             var providers = Set<ClashProxyName>()

--- a/ClashFX/General/ApiRequest.swift
+++ b/ClashFX/General/ApiRequest.swift
@@ -1002,6 +1002,7 @@ class ApiRequest {
 
     static func benchmarkSelectorPlan(
         _ plan: SelectorBenchmarkPlan,
+        reusing measurements: [SelectorBenchmarkMeasurementKey: Int] = [:],
         session: BenchmarkSession,
         result: @escaping (SelectorBenchmarkPlan.Target, Int) -> Void,
         completion: @escaping () -> Void
@@ -1012,7 +1013,6 @@ class ApiRequest {
         }
 
         let resultQueue = DispatchQueue(label: "com.clashfx.selectorBenchmarkResults")
-        var firstPassDelays = [SelectorBenchmarkMeasurementKey: Int]()
         let benchmarkStartedAt = Date()
         var didLogFirstResult = false
 
@@ -1050,108 +1050,43 @@ class ApiRequest {
             }
         }
 
-        typealias DelayTask = AdaptiveAsyncTaskRunner.Task
-        let tasks: [DelayTask] = plan.interleavedTargets.map { target in
-            return { done in
-                runTarget(target) { delay in
-                    resultQueue.sync {
-                        firstPassDelays[target.key] = delay
-                        if !didLogFirstResult {
-                            didLogFirstResult = true
-                            Logger.log(
-                                "[Proxy Delay] Selector first result after "
-                                    + String(format: "%.2f", Date().timeIntervalSince(benchmarkStartedAt))
-                                    + "s"
-                            )
-                        }
+        SelectorBenchmarkExecutor.run(
+            plan: plan,
+            reusing: measurements,
+            isCancelled: { session.isCancelled },
+            request: runTarget,
+            result: { target, delay in
+                resultQueue.sync {
+                    if !didLogFirstResult {
+                        didLogFirstResult = true
+                        Logger.log(
+                            "[Proxy Delay] Selector first result after "
+                                + String(format: "%.2f", Date().timeIntervalSince(benchmarkStartedAt)) + "s"
+                        )
                     }
-                    // Successful rows are final and can be shown immediately.
-                    // Failures remain in the testing state until their one retry
-                    // settles, avoiding a distracting fail/success flicker.
-                    if delay > 0, !session.isCancelled {
-                        result(target, delay)
-                    }
-                    done(delay > 0)
                 }
-            }
-        }
-
-        let concurrencyPolicy = plan.concurrencyPolicy
-
-        Logger.log(
-            "[Proxy Delay] Starting Selector benchmark: \(tasks.count) unique target(s), "
-                + "initial concurrency \(concurrencyPolicy.currentLimit), "
-                + "max concurrency \(concurrencyPolicy.maximumLimit)"
-        )
-        AdaptiveAsyncTaskRunner(
-            tasks: tasks,
-            policy: concurrencyPolicy,
+                result(target, delay)
+            },
             limitChanged: { previousLimit, currentLimit in
                 Logger.log(
                     "[Proxy Delay] Adaptive Selector concurrency changed "
                         + "from \(previousLimit) to \(currentLimit)"
                 )
-            }
-        )
-        .start {
-            guard !session.isCancelled else {
-                completion()
-                return
-            }
-
-            let retryPolicy = SelectorBenchmarkRetryPolicy()
-            let failedTargets = resultQueue.sync {
-                plan.targets.filter { (firstPassDelays[$0.key] ?? 0) <= 0 }
-            }
-            let retryTargets = retryPolicy.retryTargets(
-                from: plan.targets,
-                firstPassDelays: firstPassDelays
-            )
-            let retryKeys = Set(retryTargets.map(\.key))
-            for target in failedTargets where !retryKeys.contains(target.key) {
-                result(target, 0)
-            }
-            Logger.log(
-                "[Proxy Delay] Selector first pass completed in "
-                    + String(format: "%.2f", Date().timeIntervalSince(benchmarkStartedAt))
-                    + "s; \(failedTargets.count) failure(s), retrying \(retryTargets.count)"
-            )
-            guard !retryTargets.isEmpty else {
-                completion()
-                return
-            }
-
-            Logger.log(
-                "[Proxy Delay] Retrying \(retryTargets.count) failed Selector target(s), "
-                    + "max concurrency \(retryPolicy.maxConcurrentRequests)"
-            )
-            let retryTasks: [LimitedAsyncTaskRunner.Task] = retryTargets.map { target in
-                return { done in
-                    runTarget(target) { delay in
-                        if !session.isCancelled {
-                            result(target, delay)
-                        }
-                        done()
-                    }
-                }
-            }
-            LimitedAsyncTaskRunner(
-                tasks: retryTasks,
-                maxConcurrent: retryPolicy.maxConcurrentRequests
-            )
-            .start {
+            },
+            completion: {
                 guard !session.isCancelled else {
                     completion()
                     return
                 }
+
                 Logger.log(
-                    "[Proxy Delay] Selector retry tail completed after "
+                    "[Proxy Delay] Selector benchmark completed in "
                         + String(format: "%.2f", Date().timeIntervalSince(benchmarkStartedAt))
-                        + "s total"
+                        + "s"
                 )
                 completion()
             }
-        }
+        )
     }
 
     private static func benchmarkRequestTimeout(for coreTimeoutMilliseconds: Int) -> TimeInterval {

--- a/ClashFX/General/Managers/SystemProxyManager+Live.swift
+++ b/ClashFX/General/Managers/SystemProxyManager+Live.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// App-only wiring. This source is deliberately excluded from the unhosted tests.
+extension SystemProxyManager {
+    static let shared = SystemProxyManager(dependencies: SystemProxyDependencies(
+        defaults: .standard,
+        helper: { failure in
+            guard let remote = PrivilegedHelperManager.shared.helper(failture: failure) else { return nil }
+            return SystemProxyHelperClient(
+                getCurrentProxySetting: { reply in remote.getCurrentProxySetting { reply($0) } },
+                enable: { port, socks, filter, ignore, reply in
+                    remote.enableProxy(withPort: port, socksPort: socks, pac: nil,
+                                       filterInterface: filter, ignoreList: ignore, error: reply)
+                },
+                disable: { filter, reply in remote.disableProxy(withFilterInterface: filter, reply: reply) },
+                restore: { port, socks, info, filter, reply in
+                    remote.restoreProxy(withCurrentPort: port, socksPort: socks, info: info,
+                                        filterInterface: filter, error: reply)
+                }
+            )
+        },
+        currentPorts: {
+            (ConfigManager.shared.currentConfig?.usedHttpPort ?? 0,
+             ConfigManager.shared.currentConfig?.usedSocksPort ?? 0)
+        },
+        shouldSuspend: { SSIDSuspendTool.shared.shouldSuspend() },
+        disableRestoreProxy: { Settings.disableRestoreProxy },
+        filterInterface: { Settings.filterInterface },
+        proxyIgnoreList: { Settings.proxyIgnoreList },
+        liveSystemPointsToClashFX: { NetworkChangeNotifier.isCurrentSystemSetToClash() }
+    ))
+}

--- a/ClashFX/General/Managers/SystemProxyManager.swift
+++ b/ClashFX/General/Managers/SystemProxyManager.swift
@@ -3,15 +3,32 @@
 //  ClashX
 //
 
-import AppKit
-import ServiceManagement
+import Foundation
+
+/// Only proxy operations are exposed; tests cannot install a Helper or touch DNS.
+struct SystemProxyHelperClient {
+    var getCurrentProxySetting: (@escaping (Any?) -> Void) -> Void
+    var enable: (Int32, Int32, Bool, [String], @escaping (String?) -> Void) -> Void
+    var disable: (Bool, @escaping (String?) -> Void) -> Void
+    var restore: (Int32, Int32, [String: Any], Bool, @escaping (String?) -> Void) -> Void
+}
+
+struct SystemProxyDependencies {
+    let defaults: UserDefaults
+    let helper: (@escaping () -> Void) -> SystemProxyHelperClient?
+    let currentPorts: () -> (http: Int, socks: Int)
+    let shouldSuspend: () -> Bool
+    let disableRestoreProxy: () -> Bool
+    let filterInterface: () -> Bool
+    let proxyIgnoreList: () -> [String]
+    let liveSystemPointsToClashFX: () -> Bool
+    var stageTimeout: TimeInterval = 8
+}
 
 /// Owns the complete system-proxy transition. Enabling never reaches the
 /// privileged helper until the previous settings have been captured or a
 /// known-valid snapshot already exists.
 final class SystemProxyManager: NSObject {
-    static let shared = SystemProxyManager()
-
     private enum OperationError: Error {
         case helperUnavailable
         case captureFailed(String)
@@ -21,24 +38,50 @@ final class SystemProxyManager: NSObject {
     }
 
     private let transitionQueue = DispatchQueue(label: "com.clashfx.system-proxy-transition")
+    private let operations: SerializedAsyncOperationQueue
+    private var isTerminating = false
     private var policy = SystemProxyOperationPolicy()
+    private let dependencies: SystemProxyDependencies
+
+    init(dependencies: SystemProxyDependencies) {
+        self.dependencies = dependencies
+        operations = SerializedAsyncOperationQueue(queue: transitionQueue)
+        super.init()
+    }
+
+    func prepareForTermination() {
+        transitionQueue.async { self.isTerminating = true }
+    }
+
+    func resumeAfterCancelledTermination() {
+        transitionQueue.async { self.isTerminating = false }
+    }
+
+    func restoreForTermination(result: @escaping (Bool) -> Void) {
+        disableProxy(
+            port: dependencies.currentPorts().http,
+            socksPort: dependencies.currentPorts().socks,
+            forTermination: true,
+            result: result
+        )
+    }
 
     private var savedProxyInfo: [String: Any] {
-        return UserDefaults.standard.dictionary(forKey: SystemProxyOperationPolicy.savedSnapshotKey) ?? [:]
+        return dependencies.defaults.dictionary(forKey: SystemProxyOperationPolicy.savedSnapshotKey) ?? [:]
     }
 
     private var hasValidSavedProxySnapshot: Bool {
-        return UserDefaults.standard.bool(forKey: SystemProxyOperationPolicy.savedSnapshotValidityKey)
+        return dependencies.defaults.bool(forKey: SystemProxyOperationPolicy.savedSnapshotValidityKey)
     }
 
     private func saveSnapshot(_ snapshot: [String: Any]) {
-        UserDefaults.standard.set(snapshot, forKey: SystemProxyOperationPolicy.savedSnapshotKey)
-        UserDefaults.standard.set(true, forKey: SystemProxyOperationPolicy.savedSnapshotValidityKey)
+        dependencies.defaults.set(snapshot, forKey: SystemProxyOperationPolicy.savedSnapshotKey)
+        dependencies.defaults.set(true, forKey: SystemProxyOperationPolicy.savedSnapshotValidityKey)
     }
 
     private func clearSnapshot() {
-        UserDefaults.standard.removeObject(forKey: SystemProxyOperationPolicy.savedSnapshotKey)
-        UserDefaults.standard.set(false, forKey: SystemProxyOperationPolicy.savedSnapshotValidityKey)
+        dependencies.defaults.removeObject(forKey: SystemProxyOperationPolicy.savedSnapshotKey)
+        dependencies.defaults.set(false, forKey: SystemProxyOperationPolicy.savedSnapshotValidityKey)
     }
 
     private func migrateLegacySnapshotIfSafe(port: Int, socksPort: Int) -> Bool {
@@ -47,12 +90,12 @@ final class SystemProxyManager: NSObject {
         let mayMigrate = SystemProxyOperationPolicy.shouldMigrateLegacySnapshot(
             snapshot,
             validityMarker: false,
-            liveSystemPointsToClashFX: NetworkChangeNotifier.isCurrentSystemSetToClash(),
+            liveSystemPointsToClashFX: dependencies.liveSystemPointsToClashFX(),
             httpPort: port,
             socksPort: socksPort
         )
         guard mayMigrate else { return false }
-        UserDefaults.standard.set(true, forKey: SystemProxyOperationPolicy.savedSnapshotValidityKey)
+        dependencies.defaults.set(true, forKey: SystemProxyOperationPolicy.savedSnapshotValidityKey)
         Logger.log("migrated legacy system proxy snapshot", level: .info)
         return true
     }
@@ -64,8 +107,8 @@ final class SystemProxyManager: NSObject {
     }
 
     func enableProxy(complete: ((Bool) -> Void)? = nil) {
-        let port = ConfigManager.shared.currentConfig?.usedHttpPort ?? 0
-        let socketPort = ConfigManager.shared.currentConfig?.usedSocksPort ?? 0
+        let port = dependencies.currentPorts().http
+        let socketPort = dependencies.currentPorts().socks
         enableProxy(port: port, socksPort: socketPort, complete: complete)
     }
 
@@ -80,14 +123,23 @@ final class SystemProxyManager: NSObject {
             finishOnMain(false, complete)
             return
         }
-        if SSIDSuspendTool.shared.shouldSuspend() {
+        if dependencies.shouldSuspend() {
             Logger.log("not enableProxy due to ssid in disabled list", level: .info)
             finishOnMain(false, complete)
             return
         }
 
-        transitionQueue.async { [weak self] in
-            guard let self = self else { return }
+        operations.enqueue { [weak self] done in
+            guard let self = self else { done(); return }
+            guard !self.isTerminating else {
+                done()
+                self.finishOnMain(false, complete)
+                return
+            }
+            let complete: (Bool) -> Void = { success in
+                done()
+                complete?(success)
+            }
             let generation = self.policy.beginTransition()
             Logger.log("enableProxy transition \(generation)", level: .debug)
             let enable: () -> Void = { [weak self] in
@@ -102,7 +154,7 @@ final class SystemProxyManager: NSObject {
 
             let canReuseSnapshot = self.hasValidSavedProxySnapshot ||
                 self.migrateLegacySnapshotIfSafe(port: port, socksPort: socksPort)
-            guard !Settings.disableRestoreProxy, !canReuseSnapshot else {
+            guard !self.dependencies.disableRestoreProxy(), !canReuseSnapshot else {
                 enable()
                 return
             }
@@ -121,8 +173,8 @@ final class SystemProxyManager: NSObject {
         complete: (() -> Void)? = nil,
         result: ((Bool) -> Void)? = nil
     ) {
-        let port = ConfigManager.shared.currentConfig?.usedHttpPort ?? 0
-        let socketPort = ConfigManager.shared.currentConfig?.usedSocksPort ?? 0
+        let port = dependencies.currentPorts().http
+        let socketPort = dependencies.currentPorts().socks
         disableProxy(
             port: port,
             socksPort: socketPort,
@@ -136,11 +188,18 @@ final class SystemProxyManager: NSObject {
         port: Int,
         socksPort: Int,
         forceDisable: Bool = false,
+        forTermination: Bool = false,
         complete: (() -> Void)? = nil,
         result: ((Bool) -> Void)? = nil
     ) {
-        transitionQueue.async { [weak self] in
-            guard let self = self else { return }
+        operations.enqueue { [weak self] done in
+            guard let self = self else { done(); return }
+            guard !self.isTerminating || forTermination else {
+                done()
+                self.finishOnMain(false, result)
+                DispatchQueue.main.async { complete?() }
+                return
+            }
             let generation = self.policy.beginTransition()
             Logger.log("disableProxy transition \(generation)", level: .debug)
             self.disableOrRestore(
@@ -148,7 +207,10 @@ final class SystemProxyManager: NSObject {
                 port: port,
                 socksPort: socksPort,
                 forceDisable: forceDisable,
-                complete: complete,
+                complete: {
+                    done()
+                    complete?()
+                },
                 result: result
             )
         }
@@ -183,11 +245,11 @@ final class SystemProxyManager: NSObject {
                 }
             }
         }
-        settlement.scheduleTimeout(after: 8, queue: transitionQueue, outcome: {
+        settlement.scheduleTimeout(after: dependencies.stageTimeout, queue: transitionQueue, outcome: {
             return .failure(.timedOut("capturing current system proxy settings"))
         })
 
-        guard let proxy = PrivilegedHelperManager.shared.helper(failture: {
+        guard let proxy = dependencies.helper({
             _ = settlement.finish(.failure(.helperUnavailable))
         }) else {
             _ = settlement.finish(.failure(.helperUnavailable))
@@ -214,6 +276,10 @@ final class SystemProxyManager: NSObject {
         complete: ((Bool) -> Void)?
     ) {
         guard policy.acceptsCallback(for: generation) else { return }
+        guard !isTerminating else {
+            finishOnMain(false, complete)
+            return
+        }
         if replacingExternalProxy {
             forceDisableBeforeEnable(generation: generation, port: port, socksPort: socksPort, complete: complete)
             return
@@ -235,18 +301,22 @@ final class SystemProxyManager: NSObject {
                 self.invokeEnable(generation: generation, port: port, socksPort: socksPort, complete: complete)
             }
         }
-        guard let proxy = PrivilegedHelperManager.shared.helper(failture: {
+        guard let proxy = dependencies.helper({
             _ = settlement.finish(.helperUnavailable)
         }) else {
             _ = settlement.finish(.helperUnavailable)
             return
         }
-        proxy.disableProxy(withFilterInterface: Settings.filterInterface) { error in
+        proxy.disable(dependencies.filterInterface()) { error in
             _ = settlement.finish(error.map(OperationError.disableFailed))
         }
     }
 
     private func invokeEnable(generation: UInt64, port: Int, socksPort: Int, complete: ((Bool) -> Void)?) {
+        guard !isTerminating else {
+            finishOnMain(false, complete)
+            return
+        }
         let settlement = helperSettlement(generation: generation, stage: "enabling system proxy") { [weak self] error in
             guard let self = self else { return }
             if let error = error {
@@ -255,18 +325,17 @@ final class SystemProxyManager: NSObject {
                 self.finishOnMain(true, complete)
             }
         }
-        guard let proxy = PrivilegedHelperManager.shared.helper(failture: {
+        guard let proxy = dependencies.helper({
             _ = settlement.finish(.helperUnavailable)
         }) else {
             _ = settlement.finish(.helperUnavailable)
             return
         }
-        proxy.enableProxy(
-            withPort: Int32(port),
-            socksPort: Int32(socksPort),
-            pac: nil,
-            filterInterface: Settings.filterInterface,
-            ignoreList: Settings.proxyIgnoreList
+        proxy.enable(
+            Int32(port),
+            Int32(socksPort),
+            dependencies.filterInterface(),
+            dependencies.proxyIgnoreList()
         ) { error in
             _ = settlement.finish(error.map(OperationError.enableFailed))
         }
@@ -280,12 +349,13 @@ final class SystemProxyManager: NSObject {
         complete: (() -> Void)?,
         result: ((Bool) -> Void)?
     ) {
-        let shouldRestore = !Settings.disableRestoreProxy && !forceDisable && hasValidSavedProxySnapshot
+        let shouldRestore = !dependencies.disableRestoreProxy() && !forceDisable && hasValidSavedProxySnapshot
         let settlement = helperSettlement(generation: generation, stage: shouldRestore ? "restoring system proxy" : "disabling system proxy") { [weak self] error in
             guard let self = self else { return }
             let success = error == nil
             if success, shouldRestore {
-                self.clearSnapshot()
+                self.verifyRestoredSnapshot(generation: generation, complete: complete, result: result)
+                return
             }
             if let error = error {
                 self.fail(error, complete: nil)
@@ -293,25 +363,55 @@ final class SystemProxyManager: NSObject {
             self.finishOnMain(success, result)
             DispatchQueue.main.async { complete?() }
         }
-        guard let proxy = PrivilegedHelperManager.shared.helper(failture: {
+        guard let proxy = dependencies.helper({
             _ = settlement.finish(.helperUnavailable)
         }) else {
             _ = settlement.finish(.helperUnavailable)
             return
         }
         if shouldRestore {
-            proxy.restoreProxy(
-                withCurrentPort: Int32(port),
-                socksPort: Int32(socksPort),
-                info: savedProxyInfo,
-                filterInterface: Settings.filterInterface
+            proxy.restore(
+                Int32(port),
+                Int32(socksPort),
+                savedProxyInfo,
+                dependencies.filterInterface()
             ) { error in
                 _ = settlement.finish(error.map(OperationError.disableFailed))
             }
         } else {
-            proxy.disableProxy(withFilterInterface: Settings.filterInterface) { error in
+            proxy.disable(dependencies.filterInterface()) { error in
                 _ = settlement.finish(error.map(OperationError.disableFailed))
             }
+        }
+    }
+
+    private func verifyRestoredSnapshot(generation: UInt64,
+                                        complete: (() -> Void)?,
+                                        result: ((Bool) -> Void)?) {
+        let expected = savedProxyInfo
+        let settlement = helperSettlement(generation: generation, stage: "verifying restored system proxy") { [weak self] error in
+            guard let self else { return }
+            if let error {
+                self.fail(error, complete: nil)
+            } else {
+                self.clearSnapshot()
+            }
+            self.finishOnMain(error == nil, result)
+            DispatchQueue.main.async { complete?() }
+        }
+        guard let helper = dependencies.helper({
+            _ = settlement.finish(.helperUnavailable)
+        }) else {
+            _ = settlement.finish(.helperUnavailable)
+            return
+        }
+        helper.getCurrentProxySetting { info in
+            guard let actual = info as? [String: Any],
+                  SystemProxyOperationPolicy.restoredSnapshotMatches(expected: expected, actual: actual) else {
+                _ = settlement.finish(.disableFailed("restored proxy settings did not match the saved snapshot"))
+                return
+            }
+            _ = settlement.finish(nil)
         }
     }
 
@@ -326,7 +426,7 @@ final class SystemProxyManager: NSObject {
                 finish(error)
             }
         }
-        settlement.scheduleTimeout(after: 8, queue: transitionQueue, outcome: {
+        settlement.scheduleTimeout(after: dependencies.stageTimeout, queue: transitionQueue, outcome: {
             return .timedOut(stage)
         })
         return settlement

--- a/ClashFX/General/Utils/ManagedOperationSettlement.swift
+++ b/ClashFX/General/Utils/ManagedOperationSettlement.swift
@@ -5,6 +5,39 @@
 
 import Foundation
 
+/// Serializes entire asynchronous operations, including their callbacks.
+/// Merely dispatching their start onto a serial queue allows XPC writes to overlap.
+final class SerializedAsyncOperationQueue {
+    typealias Operation = (@escaping () -> Void) -> Void
+    private let queue: DispatchQueue
+    private var pending = [Operation]()
+    private var running = false
+
+    init(queue: DispatchQueue) {
+        self.queue = queue
+    }
+
+    func enqueue(_ operation: @escaping Operation) {
+        queue.async {
+            self.pending.append(operation)
+            self.startNext()
+        }
+    }
+
+    private func startNext() {
+        guard !running, !pending.isEmpty else { return }
+        running = true
+        let operation = pending.removeFirst()
+        let settlement = ManagedOperationSettlement<Void> { _ in
+            self.queue.async {
+                self.running = false
+                self.startNext()
+            }
+        }
+        operation { _ = settlement.finish(()) }
+    }
+}
+
 /// Resolves an asynchronous operation once, regardless of whether the first
 /// terminal event is a result, an error, or a timeout.
 final class ManagedOperationSettlement<Outcome> {
@@ -94,7 +127,9 @@ struct TerminationCleanupPolicy: Equatable {
         return TerminationCleanupPolicy(
             cleanEnhancedMode: observation.enhancedModeActive,
             cleanSystemProxy: cleanSystemProxy,
-            forceDisableProxy: cleanSystemProxy && observation.isProxySetByOther
+            // Restoring the captured settings remains the user's requested
+            // behavior even when a transient network change marked them external.
+            forceDisableProxy: false
         )
     }
 }

--- a/ClashFX/General/Utils/SystemProxyOperationPolicy.swift
+++ b/ClashFX/General/Utils/SystemProxyOperationPolicy.swift
@@ -32,6 +32,22 @@ struct SystemProxyOperationPolicy {
         return snapshot[captureErrorKey] as? String
     }
 
+    static func restoredSnapshotMatches(expected: [String: Any], actual: [String: Any]) -> Bool {
+        guard captureError(in: actual) == nil,
+              let currentServices = actual[capturedServiceIDsKey] as? [String] else { return false }
+        let capturedServices = Set(expected[capturedServiceIDsKey] as? [String] ?? [])
+        for serviceID in currentServices {
+            if let saved = expected[serviceID] as? [String: Any] {
+                guard let current = actual[serviceID] as? [String: Any],
+                      NSDictionary(dictionary: saved).isEqual(to: current) else { return false }
+            } else if capturedServices.contains(serviceID), actual[serviceID] != nil {
+                return false
+            }
+        }
+        // Removed services cannot be restored; new, uncaptured services are left alone.
+        return true
+    }
+
     /// Old releases persisted only the dictionary, not its ownership marker.
     /// It can be promoted exactly once, but only while the live system still
     /// points at ClashFX and the dictionary is demonstrably a non-ClashFX,

--- a/ClashFX/Models/ClashProxy.swift
+++ b/ClashFX/Models/ClashProxy.swift
@@ -347,6 +347,20 @@ struct GlobalLeafBenchmarkPresentation {
     }
 }
 
+enum ProxyBenchmarkPresentationPolicy {
+    static func allowsGlobalLeafFallback(in groupType: ClashProxyType) -> Bool {
+        return groupType == .select || groupType.isAutoGroup
+    }
+
+    static func prefersGlobal(
+        publishedAt globalDate: Date,
+        over contextualDate: Date?
+    ) -> Bool {
+        guard let contextualDate else { return true }
+        return globalDate > contextualDate
+    }
+}
+
 struct SelectorBenchmarkPresentation {
     private static let freshCacheAge: TimeInterval = 30 * 60
     private static let maximumCacheAge: TimeInterval = 24 * 60 * 60
@@ -574,7 +588,9 @@ struct SelectorBenchmarkRow {
 }
 
 struct SelectorBenchmarkConcurrencyPolicy {
-    private static let minimumConcurrency = 4
+    // Failed nodes are not proof of local congestion. Keep the normal starting
+    // capacity instead of halving throughput for the remaining timeout tail.
+    private static let minimumConcurrency = 8
     private static let initialConcurrency = 8
     private static let maximumConcurrency = 12
     private static let adjustmentStep = 4
@@ -614,7 +630,7 @@ final class AdaptiveAsyncTaskRunner {
     typealias Task = (@escaping (Bool) -> Void) -> Void
 
     private let tasks: [Task]
-    private let stateQueue = DispatchQueue(label: "com.clashfx.adaptiveProxyDelayTaskRunner")
+    private let stateQueue: DispatchQueue
     private let limitChanged: ((Int, Int) -> Void)?
     private var policy: SelectorBenchmarkConcurrencyPolicy
     private var nextTaskIndex = 0
@@ -633,9 +649,11 @@ final class AdaptiveAsyncTaskRunner {
 
     init(tasks: [Task],
          policy: SelectorBenchmarkConcurrencyPolicy,
+         stateQueue: DispatchQueue = DispatchQueue(label: "com.clashfx.adaptiveProxyDelayTaskRunner"),
          limitChanged: ((Int, Int) -> Void)? = nil) {
         self.tasks = tasks
         self.policy = policy
+        self.stateQueue = stateQueue
         self.limitChanged = limitChanged
         remainingLaunchesInCohort = policy.currentLimit
     }
@@ -710,32 +728,48 @@ final class AdaptiveAsyncTaskRunner {
     }
 }
 
-struct SelectorBenchmarkRetryPolicy {
-    let maxConcurrentRequests = 2
-    let maxRetryRequests = 4
-
-    func retryTargets(
-        from targets: [SelectorBenchmarkPlan.Target],
-        firstPassDelays: [SelectorBenchmarkMeasurementKey: Int]
-    ) -> [SelectorBenchmarkPlan.Target] {
-        return Array(targets
-            .filter { (firstPassDelays[$0.key] ?? 0) <= 0 }
-            .prefix(maxRetryRequests))
-    }
-
-    func finalDelay(
-        for target: SelectorBenchmarkPlan.Target,
-        firstPassDelays: [SelectorBenchmarkMeasurementKey: Int],
-        retryDelays: [SelectorBenchmarkMeasurementKey: Int]
-    ) -> Int {
-        return retryDelays[target.key] ?? firstPassDelays[target.key] ?? 0
-    }
-}
-
 struct SelectorBenchmarkAutomaticRetestTarget {
     let groupName: ClashProxyName
     let benchmarkURL: String
     let expectedStatus: String?
+}
+
+/// Shared production executor; transport and scheduling can be isolated in tests.
+enum SelectorBenchmarkExecutor {
+    static func run(
+        plan: SelectorBenchmarkPlan,
+        reusing measurements: [SelectorBenchmarkMeasurementKey: Int] = [:],
+        isCancelled: @escaping () -> Bool,
+        schedulingQueue: DispatchQueue = DispatchQueue(label: "com.clashfx.selectorBenchmarkExecutor"),
+        request: @escaping (SelectorBenchmarkPlan.Target, @escaping (Int) -> Void) -> Void,
+        result: @escaping (SelectorBenchmarkPlan.Target, Int) -> Void,
+        limitChanged: ((Int, Int) -> Void)? = nil,
+        completion: @escaping () -> Void
+    ) {
+        let pending = plan.interleavedTargets.filter { target in
+            guard !isCancelled() else { return false }
+            guard let delay = measurements[target.key], delay > 0 else { return true }
+            result(target, delay)
+            return false
+        }
+        let tasks: [AdaptiveAsyncTaskRunner.Task] = pending.map { target in
+            return { done in
+                guard !isCancelled() else { done(false); return }
+                let settlement = ManagedOperationSettlement<Int> { delay in
+                    if !isCancelled() { result(target, delay) }
+                    done(delay > 0)
+                }
+                request(target) { settlement.finish($0) }
+            }
+        }
+        Logger.log("[Proxy Delay] Selector requests: \(tasks.count), reused: \(plan.targets.count - pending.count)")
+        AdaptiveAsyncTaskRunner(
+            tasks: tasks,
+            policy: SelectorBenchmarkConcurrencyPolicy(targetCount: tasks.count),
+            stateQueue: schedulingQueue,
+            limitChanged: limitChanged
+        ).start(completion: completion)
+    }
 }
 
 struct SelectorBenchmarkPlan {
@@ -748,6 +782,37 @@ struct SelectorBenchmarkPlan {
     let orderedRows: [SelectorBenchmarkRow]
     let targets: [Target]
     let selectedAutomaticRetest: SelectorBenchmarkAutomaticRetestTarget?
+
+    /// Reuse only successful direct-leaf measurements made during this same
+    /// action, with exactly the Selector's URL, timeout and status semantics.
+    /// Nested groups measure a selected path, not an independently named leaf.
+    func reusableMeasurements(group: ClashProxy,
+                              candidateDelays: [ClashProxyName: Int],
+                              timeout: Int) -> [SelectorBenchmarkMeasurementKey: Int] {
+        guard let retest = selectedAutomaticRetest,
+              retest.groupName == group.name,
+              group.type.isAutoGroup,
+              retest.benchmarkURL == group.effectiveBenchmarkURL(fallback: retest.benchmarkURL),
+              retest.expectedStatus?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false,
+              group.expectedStatus?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false,
+              let snapshot = group.enclosingResp else { return [:] }
+        let members = Set(group.all ?? [])
+        var measurements = [SelectorBenchmarkMeasurementKey: Int]()
+        for target in targets {
+            let key = target.key
+            guard key.benchmarkURL == retest.benchmarkURL,
+                  key.timeout == timeout,
+                  members.contains(key.proxyName),
+                  let leaf = snapshot.proxiesMap[key.proxyName],
+                  leaf.all == nil,
+                  !ClashProxyType.isProxyGroup(leaf),
+                  leaf.enclosingProvider?.name == key.providerName,
+                  (leaf.enclosingProvider == nil ? SelectorBenchmarkEndpoint.inline : .provider) == key.endpoint,
+                  let delay = candidateDelays[key.proxyName], delay > 0 else { continue }
+            measurements[key] = delay
+        }
+        return measurements
+    }
 
     var interleavedTargets: [Target] {
         var bucketOrder = [SelectorBenchmarkSchedulingBucket]()
@@ -1099,6 +1164,7 @@ class ClashProxyResp {
         for provider in providerResp.providers.values {
             for proxy in provider.proxies {
                 proxy.enclosingProvider = provider
+                proxy.enclosingResp = self
                 proxiesMap[proxy.name] = proxy
                 proxies.append(proxy)
             }

--- a/ClashFX/Resources/DashboardCompatibility/clashfx-compat.js
+++ b/ClashFX/Resources/DashboardCompatibility/clashfx-compat.js
@@ -1,7 +1,9 @@
 (function () {
   'use strict';
 
-  var COMPATIBILITY_REVISION = '2026.09.07.1';
+  var COMPATIBILITY_REVISION = '2026.09.08.1';
+  var COLOR_MIX_SYNTAX_PROBE = 'color-mix(in oklab, rgb(64, 128, 192) 50%, transparent)';
+  var COLOR_MIX_RENDERED_PROBE = 'color-mix(in oklab, var(--clashfx-probe-color) 50%, transparent)';
   var existingDiagnostics = window.__CLASHFX_DASHBOARD_COMPAT__;
   if (existingDiagnostics && existingDiagnostics.revision) return;
 
@@ -109,29 +111,168 @@
   };
 
   diagnostics.syntaxSupport = !!(window.CSS && window.CSS.supports &&
-    window.CSS.supports('color', 'color-mix(in srgb, currentColor 50%, transparent)'));
+    window.CSS.supports('color', COLOR_MIX_SYNTAX_PROBE));
+
+  function clamp(value, minimum, maximum) {
+    return Math.min(maximum, Math.max(minimum, value));
+  }
+
+  function component(token, percentageScale) {
+    if (!token || typeof token !== 'string') return null;
+    var isPercentage = /%$/.test(token);
+    var number = Number(token.replace(/%$/, ''));
+    if (!isFinite(number)) return null;
+    return isPercentage ? number * percentageScale / 100 : number;
+  }
+
+  function alphaComponent(token) {
+    if (!token) return 1;
+    var alpha = component(token, 1);
+    return alpha === null ? null : clamp(alpha, 0, 1);
+  }
+
+  function colorResult(red, green, blue, alpha, serialization) {
+    if (![red, green, blue, alpha].every(isFinite)) return null;
+    return {
+      red: clamp(red, 0, 255),
+      green: clamp(green, 0, 255),
+      blue: clamp(blue, 0, 255),
+      alpha: clamp(alpha, 0, 1),
+      serialization: serialization
+    };
+  }
+
+  function encodedSRGB(value) {
+    var encoded = value <= 0.0031308
+      ? 12.92 * value
+      : 1.055 * Math.pow(value, 1 / 2.4) - 0.055;
+    return clamp(encoded, 0, 1) * 255;
+  }
+
+  function labToSRGB(lightness, axisA, axisB, alpha) {
+    var fy = (lightness + 16) / 116;
+    var fx = fy + axisA / 500;
+    var fz = fy - axisB / 200;
+    var epsilon = 216 / 24389;
+    var kappa = 24389 / 27;
+    var inverse = function (value) {
+      var cube = value * value * value;
+      return cube > epsilon ? cube : (116 * value - 16) / kappa;
+    };
+
+    // CSS lab() uses a D50 white point. Adapt it to the D65 white point used by sRGB.
+    var x50 = inverse(fx) * 0.96422;
+    var y50 = inverse(fy);
+    var z50 = inverse(fz) * 0.82521;
+    var x65 = 0.9555766 * x50 - 0.0230393 * y50 + 0.0631636 * z50;
+    var y65 = -0.0282895 * x50 + 1.0099416 * y50 + 0.0210077 * z50;
+    var z65 = 0.0122982 * x50 - 0.0204830 * y50 + 1.3299098 * z50;
+
+    return colorResult(
+      encodedSRGB(3.2404542 * x65 - 1.5371385 * y65 - 0.4985314 * z65),
+      encodedSRGB(-0.969266 * x65 + 1.8760108 * y65 + 0.041556 * z65),
+      encodedSRGB(0.0556434 * x65 - 0.2040259 * y65 + 1.0572252 * z65),
+      alpha,
+      'lab'
+    );
+  }
+
+  function oklabToSRGB(lightness, axisA, axisB, alpha) {
+    var l = lightness + 0.3963377774 * axisA + 0.2158037573 * axisB;
+    var m = lightness - 0.1055613458 * axisA - 0.0638541728 * axisB;
+    var s = lightness - 0.0894841775 * axisA - 1.291485548 * axisB;
+    l = l * l * l;
+    m = m * m * m;
+    s = s * s * s;
+
+    return colorResult(
+      encodedSRGB(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s),
+      encodedSRGB(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s),
+      encodedSRGB(-0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s),
+      alpha,
+      'oklab'
+    );
+  }
+
+  function functionalComponents(value, functionName) {
+    var expression = new RegExp('^' + functionName + '\\(\\s*(.*?)\\s*\\)$', 'i').exec(value);
+    if (!expression) return null;
+    var sections = expression[1].split(/\s*\/\s*/);
+    var channels = sections[0].indexOf(',') >= 0
+      ? sections[0].split(/\s*,\s*/)
+      : sections[0].trim().split(/\s+/);
+    return { channels: channels, alpha: sections[1] || null };
+  }
 
   function parseRenderedColor(value) {
     if (!value || typeof value !== 'string') return null;
-    var rgba = value.match(/^rgba\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*\)$/i);
-    if (rgba) {
-      return {
-        red: Number(rgba[1]),
-        green: Number(rgba[2]),
-        blue: Number(rgba[3]),
-        alpha: Number(rgba[4]),
-        serialization: 'rgba'
-      };
+    value = value.trim();
+    if (value.toLowerCase() === 'transparent') return colorResult(0, 0, 0, 0, 'transparent');
+
+    var hex = /^#([0-9a-f]{3,8})$/i.exec(value);
+    if (hex) {
+      var digits = hex[1];
+      if (digits.length === 3 || digits.length === 4) {
+        digits = digits.split('').map(function (digit) { return digit + digit; }).join('');
+      }
+      if (digits.length === 6 || digits.length === 8) {
+        return colorResult(
+          parseInt(digits.slice(0, 2), 16),
+          parseInt(digits.slice(2, 4), 16),
+          parseInt(digits.slice(4, 6), 16),
+          digits.length === 8 ? parseInt(digits.slice(6, 8), 16) / 255 : 1,
+          'hex'
+        );
+      }
     }
-    var srgb = value.match(/^color\(\s*srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s*\/\s*([\d.]+)\s*\)$/i);
+
+    var rgb = functionalComponents(value, 'rgba?');
+    if (rgb && (rgb.channels.length === 3 || rgb.channels.length === 4)) {
+      var rgbAlpha = alphaComponent(rgb.alpha || rgb.channels[3]);
+      var red = component(rgb.channels[0], 255);
+      var green = component(rgb.channels[1], 255);
+      var blue = component(rgb.channels[2], 255);
+      if (red !== null && green !== null && blue !== null && rgbAlpha !== null) {
+        return colorResult(red, green, blue, rgbAlpha, 'rgb');
+      }
+    }
+
+    var srgb = /^color\(\s*srgb\s+(.*?)\s*\)$/i.exec(value);
     if (srgb) {
-      return {
-        red: Number(srgb[1]) * 255,
-        green: Number(srgb[2]) * 255,
-        blue: Number(srgb[3]) * 255,
-        alpha: Number(srgb[4]),
-        serialization: 'color(srgb)'
-      };
+      var srgbSections = srgb[1].split(/\s*\/\s*/);
+      var srgbChannels = srgbSections[0].trim().split(/\s+/);
+      var srgbAlpha = alphaComponent(srgbSections[1]);
+      if (srgbChannels.length === 3 && srgbAlpha !== null) {
+        return colorResult(
+          Number(srgbChannels[0]) * 255,
+          Number(srgbChannels[1]) * 255,
+          Number(srgbChannels[2]) * 255,
+          srgbAlpha,
+          'color(srgb)'
+        );
+      }
+    }
+
+    var lab = functionalComponents(value, 'lab');
+    if (lab && lab.channels.length === 3) {
+      var labLightness = component(lab.channels[0], 100);
+      var labA = component(lab.channels[1], 125);
+      var labB = component(lab.channels[2], 125);
+      var labAlpha = alphaComponent(lab.alpha);
+      if (labLightness !== null && labA !== null && labB !== null && labAlpha !== null) {
+        return labToSRGB(labLightness, labA, labB, labAlpha);
+      }
+    }
+
+    var oklab = functionalComponents(value, 'oklab');
+    if (oklab && oklab.channels.length === 3) {
+      var oklabLightness = component(oklab.channels[0], 1);
+      var oklabA = component(oklab.channels[1], 0.4);
+      var oklabB = component(oklab.channels[2], 0.4);
+      var oklabAlpha = alphaComponent(oklab.alpha);
+      if (oklabLightness !== null && oklabA !== null && oklabB !== null && oklabAlpha !== null) {
+        return oklabToSRGB(oklabLightness, oklabA, oklabB, oklabAlpha);
+      }
     }
     return null;
   }
@@ -147,14 +288,14 @@
     container.style.left = '-9999px';
     container.style.visibility = 'hidden';
     container.style.pointerEvents = 'none';
-    probe.style.color = 'rgb(64, 128, 192)';
+    probe.style.setProperty('--clashfx-probe-color', 'rgb(64, 128, 192)');
     container.appendChild(probe);
     root.appendChild(container);
 
     var observed = null;
     try {
       // Assign after mounting so WebKit must resolve currentColor in a real tree.
-      probe.style.backgroundColor = 'color-mix(in srgb, currentColor 50%, transparent)';
+      probe.style.backgroundColor = COLOR_MIX_RENDERED_PROBE;
       observed = parseRenderedColor(nativeGetComputedStyle(probe).backgroundColor || '');
       diagnostics.observedProbe = observed;
     } catch (_) {
@@ -186,14 +327,38 @@
     probe.style.pointerEvents = 'none';
     root.appendChild(probe);
 
+    function activeThemePalette() {
+      var themeName = root.getAttribute('data-theme');
+      if (!themeName && document.querySelector) {
+        var selectedTheme = document.querySelector('input.theme-controller:checked');
+        themeName = selectedTheme && selectedTheme.value;
+      }
+      if (!themeName && window.matchMedia) {
+        themeName = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      }
+      return themePalette[themeName] || themePalette.light;
+    }
+
+    function safeFallbackColor(variableName) {
+      var palette = activeThemePalette();
+      var value = palette.content;
+      if (/--color-base-(100|200|300)$/.test(variableName)) value = palette.base;
+      else if (/--color-primary/.test(variableName)) value = palette.primary;
+      else if (/--color-error/.test(variableName)) value = '#ff657f';
+      else if (/--color-success/.test(variableName)) value = '#00d193';
+      else if (/--color-warning/.test(variableName)) value = '#f9b800';
+      else if (/--color-info/.test(variableName)) value = '#00bafc';
+      return parseRenderedColor(value) || colorResult(127, 127, 127, 1, 'safe-fallback');
+    }
+
     function rgbaFor(variableName, alpha) {
       probe.style.color = '';
       probe.style.color = 'var(' + variableName + ')';
       var value = nativeGetComputedStyle(probe).color || '';
-      var match = value.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/i);
-      if (!match) return 'rgba(0, 0, 0, ' + alpha + ')';
-      return 'rgba(' + Math.round(Number(match[1])) + ', ' +
-        Math.round(Number(match[2])) + ', ' + Math.round(Number(match[3])) + ', ' + alpha + ')';
+      var parsed = parseRenderedColor(value) || safeFallbackColor(variableName);
+      return 'rgba(' + Math.round(parsed.red) + ', ' +
+        Math.round(parsed.green) + ', ' + Math.round(parsed.blue) + ', ' +
+        clamp(alpha * parsed.alpha, 0, 1) + ')';
     }
 
     function addUtilityClass(className) {
@@ -296,6 +461,13 @@
   function activateCompatibility() {
     diagnostics.renderedProbe = supportsRenderedColorMix();
     if (!diagnostics.renderedProbe) installLegacyColorFallbacks();
+  }
+
+  if (window.__CLASHFX_DASHBOARD_COMPAT_TESTING__) {
+    diagnostics.testing = {
+      parseRenderedColor: parseRenderedColor,
+      renderedProbeExpression: COLOR_MIX_RENDERED_PROBE
+    };
   }
 
   if (document.readyState === 'loading') {

--- a/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
+++ b/ClashFX/Support Files/zh-Hans.lproj/Localizable.strings
@@ -321,6 +321,7 @@
 "Testing" = "测速中";
 
 "Benchmark unavailable" = "测速不可用";
+"Proxy cleanup failed. ClashFX remains open; please try quitting again." = "代理设置恢复失败。ClashFX 将保持运行，请再次尝试退出。";
 
 /* No comment provided by engineer. */
 "The active connections will be interrupted." = "活动的连接将被强制打断。";

--- a/ClashFX/Views/ProxyGroupMenuItemView.swift
+++ b/ClashFX/Views/ProxyGroupMenuItemView.swift
@@ -271,7 +271,7 @@ class ProxyGroupMenuItemView: MenuItemBaseView {
     }
 
     private func render(_ presentation: AutomaticGroupBenchmarkPresentation) {
-        effectView.alphaValue = presentation.isStale ? 0.65 : 1
+        effectView.alphaValue = 1
         let leaf = presentation.finalLeaf ?? presentation.rowState.presentationName
         if let result = presentation.rowState.delayDisplay {
             selectProxyLabel.stringValue = "\(leaf) · \(result)"

--- a/ClashFX/Views/ProxyGroupSpeedTestMenuItem.swift
+++ b/ClashFX/Views/ProxyGroupSpeedTestMenuItem.swift
@@ -342,6 +342,8 @@ private class ProxyGroupSpeedTestMenuItemView: MenuItemBaseView {
         speedTestItem.beginBenchmarkAction(session: session)
 
         var plan: SelectorBenchmarkPlan?
+        var preflightSnapshot: ClashProxyResp?
+        var reusableMeasurements = [SelectorBenchmarkMeasurementKey: Int]()
         var pendingRows = Set<ClashProxyName>()
         var selectorBenchmarkURL = Settings.benchMarkUrl
         let sessionIdentifier = UUID()
@@ -504,10 +506,20 @@ private class ProxyGroupSpeedTestMenuItemView: MenuItemBaseView {
                                 return
                             }
 
+                            // Restore Provider ownership on the fresh topology
+                            // before matching direct candidates to Selector targets.
+                            if let providers = preflightSnapshot?.enclosingProviderResp {
+                                snapshot.updateProvider(providers)
+                            }
                             AutomaticChildBenchmarkStore.settle(
                                 group: freshGroup,
                                 candidateDelays: result.candidateDelays,
                                 sessionIdentifier: sessionIdentifier
+                            )
+                            reusableMeasurements = plan.reusableMeasurements(
+                                group: freshGroup,
+                                candidateDelays: result.candidateDelays,
+                                timeout: 5000
                             )
 
                             let retestSnapshot = AutomaticGroupRetestSnapshot.make(
@@ -578,6 +590,7 @@ private class ProxyGroupSpeedTestMenuItemView: MenuItemBaseView {
             selectorBenchmarkURL = selector.effectiveBenchmarkURL(
                 fallback: Settings.benchMarkUrl
             )
+            preflightSnapshot = response
             plan = SelectorBenchmarkPlan.make(
                 selector: selector,
                 snapshot: response,
@@ -644,6 +657,7 @@ private class ProxyGroupSpeedTestMenuItemView: MenuItemBaseView {
                 retestSelectedAutomaticGroup {
                     ApiRequest.benchmarkSelectorPlan(
                         plan,
+                        reusing: reusableMeasurements,
                         session: session,
                         result: publishResult,
                         completion: finish

--- a/ClashFX/Views/ProxyMenuItem.swift
+++ b/ClashFX/Views/ProxyMenuItem.swift
@@ -312,7 +312,9 @@ class ProxyMenuItem: NSMenuItem {
                   presentation.rowName == proxyName else {
                 guard let presentation = note.object as? GlobalLeafBenchmarkPresentation,
                       presentation.identity == benchmarkIdentity,
-                      parentGroupType == .select else { return }
+                      ProxyBenchmarkPresentationPolicy.allowsGlobalLeafFallback(
+                          in: parentGroupType
+                      ) else { return }
                 applyGlobalLeafBenchmarkPresentation(presentation)
                 return
             }
@@ -386,7 +388,6 @@ class ProxyMenuItem: NSMenuItem {
             delay: presentation.rowState.delayDisplay,
             rawValue: presentation.rowState.rawDelay
         )
-        applyStaleAppearance(presentation.isStale)
     }
 
     private func applyAutomaticChildBenchmarkPresentation(
@@ -398,7 +399,6 @@ class ProxyMenuItem: NSMenuItem {
             delay: presentation.rowState.delayDisplay,
             rawValue: presentation.rowState.rawDelay
         )
-        applyStaleAppearance(presentation.isStale)
     }
 
     private func applyGlobalLeafBenchmarkPresentation(
@@ -413,7 +413,6 @@ class ProxyMenuItem: NSMenuItem {
             delay: presentation.rowState.delayDisplay,
             rawValue: presentation.rowState.rawDelay
         )
-        applyStaleAppearance(presentation.isStale)
     }
 
     private func updateAutomaticChildBenchmarkPresentation(from info: ClashProxy) {
@@ -422,11 +421,22 @@ class ProxyMenuItem: NSMenuItem {
             updatePresentation(name: proxyName, delay: nil, rawValue: nil)
             return
         }
+        let globalPresentation = info.all == nil
+            ? GlobalLeafBenchmarkPresentationStore.presentation(for: info)
+            : nil
         if let presentation = AutomaticChildBenchmarkStore.presentation(
             group: group,
             rowName: proxyName
         ) {
-            applyAutomaticChildBenchmarkPresentation(presentation)
+            if let globalPresentation,
+               ProxyBenchmarkPresentationPolicy.prefersGlobal(
+                   publishedAt: globalPresentation.publishedAt,
+                   over: presentation.publishedAt
+               ) {
+                applyGlobalLeafBenchmarkPresentation(globalPresentation)
+            } else {
+                applyAutomaticChildBenchmarkPresentation(presentation)
+            }
             return
         }
 
@@ -434,7 +444,13 @@ class ProxyMenuItem: NSMenuItem {
         let evidenceProxy = info.testState(for: parentBenchmarkURL) == nil
             ? (finalLeaf(from: info) ?? info)
             : info
-        guard let state = evidenceProxy.testState(for: parentBenchmarkURL),
+        let state = evidenceProxy.testState(for: parentBenchmarkURL)
+        if let globalPresentation,
+           globalPresentation.isNewer(than: state) {
+            applyGlobalLeafBenchmarkPresentation(globalPresentation)
+            return
+        }
+        guard let state,
               let history = state.history.last else {
             updatePresentation(name: proxyName, delay: nil, rawValue: nil)
             return
@@ -547,22 +563,6 @@ class ProxyMenuItem: NSMenuItem {
         } else {
             attributedTitle = getAttributedTitle(name: name, delay: delay)
         }
-    }
-
-    private func applyStaleAppearance(_ stale: Bool) {
-        guard stale else { return }
-        if enableShowUsingView {
-            view?.alphaValue = 0.65
-            return
-        }
-        guard let attributedTitle else { return }
-        let muted = NSMutableAttributedString(attributedString: attributedTitle)
-        muted.addAttribute(
-            .foregroundColor,
-            value: NSColor.secondaryLabelColor,
-            range: NSRange(location: 0, length: muted.length)
-        )
-        self.attributedTitle = muted
     }
 }
 

--- a/ClashFXTests/BenchmarkRegressionSupport.swift
+++ b/ClashFXTests/BenchmarkRegressionSupport.swift
@@ -1,11 +1,13 @@
 import Foundation
 
-/// The unhosted unit-test bundle compiles the pure proxy-model sources directly.
+/// The unhosted unit-test bundle compiles model, executor and proxy-manager sources directly.
 /// These test-only shims satisfy their logging/date-format dependencies without
 /// loading ClashFX's AppDelegate, controller, helper, or live configuration.
 enum ClashLogLevel {
     case info
     case warning
+    case debug
+    case error
 }
 
 enum Logger {

--- a/ClashFXTests/BenchmarkRegressionTests.swift
+++ b/ClashFXTests/BenchmarkRegressionTests.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import JavaScriptCore
 import WebKit
 import XCTest
 
@@ -212,6 +213,35 @@ final class BenchmarkURLSettingsTests: XCTestCase {
 }
 
 final class ManagedOperationSettlementTests: XCTestCase {
+    func testAsyncOperationsWaitForCompletionAndIgnoreDuplicateCompletion() {
+        let queue = DispatchQueue(label: "test.serial-operations")
+        let operations = SerializedAsyncOperationQueue(queue: queue)
+        let started = expectation(description: "first operation started")
+        let drained = expectation(description: "all operations completed")
+        var events = [Int]()
+        var finishFirst: (() -> Void)?
+        var finishSecond: (() -> Void)?
+        operations.enqueue { done in
+            events.append(1)
+            finishFirst = done
+            started.fulfill()
+        }
+        operations.enqueue { done in
+            events.append(2)
+            finishSecond = done
+        }
+        operations.enqueue { done in
+            events.append(3)
+            done()
+            drained.fulfill()
+        }
+        wait(for: [started], timeout: 2)
+        queue.sync { XCTAssertEqual(events, [1]); finishFirst?(); finishFirst?() }
+        queue.sync { XCTAssertEqual(events, [1, 2]); finishSecond?() }
+        wait(for: [drained], timeout: 2)
+        queue.sync { XCTAssertEqual(events, [1, 2, 3]) }
+    }
+
     func testNormalResultFiresOnce() {
         var outcomes = [String]()
         let settlement = ManagedOperationSettlement<String> { outcomes.append($0) }
@@ -250,6 +280,34 @@ final class ManagedOperationSettlementTests: XCTestCase {
 }
 
 final class SystemProxyOperationPolicyTests: XCTestCase {
+    func testRestoreVerificationChecksPACAndEnabledFlags() {
+        let key = SystemProxyOperationPolicy.capturedServiceIDsKey
+        let original: [String: Any] = [
+            key: ["wifi"],
+            "wifi": ["ProxyAutoConfigEnable": 1, "ProxyAutoConfigURLString": "https://example.test/proxy.pac", "HTTPEnable": 0]
+        ]
+        XCTAssertTrue(SystemProxyOperationPolicy.restoredSnapshotMatches(expected: original, actual: original))
+        var changed = original
+        changed["wifi"] = ["ProxyAutoConfigEnable": 0, "ProxyAutoConfigURLString": "https://example.test/proxy.pac", "HTTPEnable": 0]
+        XCTAssertFalse(SystemProxyOperationPolicy.restoredSnapshotMatches(expected: original, actual: changed))
+        changed["wifi"] = ["ProxyAutoConfigEnable": 1, "ProxyAutoConfigURLString": "https://wrong.test/proxy.pac", "HTTPEnable": 0]
+        XCTAssertFalse(SystemProxyOperationPolicy.restoredSnapshotMatches(expected: original, actual: changed))
+        XCTAssertFalse(SystemProxyOperationPolicy.restoredSnapshotMatches(expected: original, actual: [:]))
+        changed = original
+        changed[SystemProxyOperationPolicy.captureErrorKey] = "read failed"
+        XCTAssertFalse(SystemProxyOperationPolicy.restoredSnapshotMatches(expected: original, actual: changed))
+    }
+
+    func testRestoreVerificationHandlesAbsentAndNewNetworkServices() {
+        let key = SystemProxyOperationPolicy.capturedServiceIDsKey
+        let original: [String: Any] = [key: ["wifi", "removed"], "removed": ["HTTPEnable": 1]]
+        let actual: [String: Any] = [key: ["wifi", "new"], "new": ["HTTPEnable": 1]]
+        XCTAssertTrue(SystemProxyOperationPolicy.restoredSnapshotMatches(expected: original, actual: actual))
+        var changed = actual
+        changed["wifi"] = ["HTTPEnable": 0]
+        XCTAssertFalse(SystemProxyOperationPolicy.restoredSnapshotMatches(expected: original, actual: changed))
+    }
+
     private func clashSnapshot(httpPort: Int = 7890, socksPort: Int = 7891) -> [String: Any] {
         return [
             "wifi": [
@@ -400,13 +458,13 @@ final class TerminationCleanupPolicyTests: XCTestCase {
         XCTAssertFalse(policy.forceDisableProxy)
     }
 
-    func testExternallyOwnedProxyStateSelectsForceDisable() {
+    func testExternalChangeMarkerDoesNotBypassOriginalProxyRestoration() {
         let policy = TerminationCleanupPolicy.make(observation: TerminationCleanupObservation(
             enhancedModeActive: false, proxyPortAutoSet: false, isProxySetByOther: true,
             currentSystemSetToClash: true, hasInterfaceProxySetToClash: false
         ))
         XCTAssertTrue(policy.cleanSystemProxy)
-        XCTAssertTrue(policy.forceDisableProxy)
+        XCTAssertFalse(policy.forceDisableProxy)
     }
 }
 
@@ -477,6 +535,126 @@ final class BenchmarkRegressionTests: XCTestCase {
         })
         let data = try! JSONSerialization.data(withJSONObject: ["proxies": proxies])
         return ClashProxyResp(data)
+    }
+
+    func testDashboardCompatibilityConvertsLabThemeColorsWithoutFallingBackToBlack() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let scriptURL = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("ClashFX/Resources/DashboardCompatibility/clashfx-compat.js")
+        let source = try String(contentsOf: scriptURL, encoding: .utf8)
+        let context = try XCTUnwrap(JSContext())
+        var exception: String?
+        context.exceptionHandler = { _, value in
+            exception = value?.toString()
+        }
+        context.evaluateScript("""
+        var window = {
+          __CLASHFX_DASHBOARD_COMPAT_TESTING__: true,
+          CSS: { supports: function () { return false; } },
+          getComputedStyle: function () { return {}; }
+        };
+        var document = {
+          readyState: 'loading',
+          addEventListener: function () {}
+        };
+        """)
+        context.evaluateScript(source)
+        XCTAssertNil(exception)
+
+        func converted(_ cssColor: String) throws -> (Double, Double, Double) {
+            let argumentData = try JSONSerialization.data(withJSONObject: [cssColor])
+            let argumentJSON = try XCTUnwrap(String(data: argumentData, encoding: .utf8))
+            let expression = "window.__CLASHFX_DASHBOARD_COMPAT__.testing.parseRenderedColor(\(argumentJSON)[0])"
+            let value = try XCTUnwrap(context.evaluateScript(expression))
+            XCTAssertFalse(value.isNull)
+            return (
+                value.forProperty("red").toDouble(),
+                value.forProperty("green").toDouble(),
+                value.forProperty("blue").toDouble()
+            )
+        }
+
+        let darkBackground = try converted("lab(13.3466% -1.2732 -5.67451)")
+        XCTAssertEqual(darkBackground.0, 0x1D, accuracy: 1.5)
+        XCTAssertEqual(darkBackground.1, 0x23, accuracy: 1.5)
+        XCTAssertEqual(darkBackground.2, 0x2A, accuracy: 1.5)
+
+        let darkContent = try converted("lab(97.3754% -1.86676 -10.6283)")
+        XCTAssertEqual(darkContent.0, 0xF2, accuracy: 8)
+        XCTAssertEqual(darkContent.1, 0xF8, accuracy: 8)
+        XCTAssertEqual(darkContent.2, 0xFF, accuracy: 8)
+
+        let probeExpression = context.evaluateScript(
+            "window.__CLASHFX_DASHBOARD_COMPAT__.testing.renderedProbeExpression"
+        )?.toString()
+        XCTAssertEqual(
+            probeExpression,
+            "color-mix(in oklab, var(--clashfx-probe-color) 50%, transparent)"
+        )
+    }
+
+    func testProviderMergePreservesProxySnapshotOwnership() throws {
+        let response = snapshot([
+            [
+                "name": "Selector",
+                "type": "Selector",
+                "all": ["Provider Node"],
+                "now": "Provider Node",
+                "history": []
+            ],
+            [
+                "name": "Provider Node",
+                "type": "Vless",
+                "history": []
+            ]
+        ])
+        let providerData = try JSONSerialization.data(withJSONObject: [
+            "providers": [
+                "Subscription": [
+                    "name": "Subscription",
+                    "type": "Proxy",
+                    "vehicleType": "HTTP",
+                    "proxies": [
+                        [
+                            "name": "Provider Node",
+                            "type": "Vless",
+                            "history": []
+                        ]
+                    ]
+                ]
+            ]
+        ])
+        let providerResponse = try ClashProviderResp.decoder.decode(
+            ClashProviderResp.self,
+            from: providerData
+        )
+
+        response.updateProvider(providerResponse)
+
+        let mergedNode = try XCTUnwrap(response.proxiesMap["Provider Node"])
+        XCTAssertTrue(mergedNode.enclosingResp === response)
+        XCTAssertEqual(mergedNode.enclosingProvider?.name, "Subscription")
+    }
+
+    func testGlobalLeafFallbackCoversSelectableAndAutomaticGroups() {
+        XCTAssertTrue(ProxyBenchmarkPresentationPolicy.allowsGlobalLeafFallback(in: .select))
+        XCTAssertTrue(ProxyBenchmarkPresentationPolicy.allowsGlobalLeafFallback(in: .urltest))
+        XCTAssertTrue(ProxyBenchmarkPresentationPolicy.allowsGlobalLeafFallback(in: .fallback))
+        XCTAssertTrue(ProxyBenchmarkPresentationPolicy.allowsGlobalLeafFallback(in: .loadBalance))
+        XCTAssertFalse(ProxyBenchmarkPresentationPolicy.allowsGlobalLeafFallback(in: .relay))
+
+        let older = Date(timeIntervalSince1970: 100)
+        let newer = Date(timeIntervalSince1970: 200)
+        XCTAssertTrue(ProxyBenchmarkPresentationPolicy.prefersGlobal(
+            publishedAt: newer,
+            over: older
+        ))
+        XCTAssertFalse(ProxyBenchmarkPresentationPolicy.prefersGlobal(
+            publishedAt: older,
+            over: newer
+        ))
     }
 
     func testSelectorPlanSharesNestedAutomaticFinalLeaf() throws {
@@ -646,7 +824,7 @@ final class BenchmarkRegressionTests: XCTestCase {
 
         XCTAssertEqual(plan.targets.count, 25)
         XCTAssertEqual(plan.maxConcurrentRequests, 8)
-        XCTAssertEqual(plan.concurrencyPolicy.minimumLimit, 4)
+        XCTAssertEqual(plan.concurrencyPolicy.minimumLimit, 8)
         XCTAssertEqual(plan.concurrencyPolicy.maximumLimit, 12)
     }
 
@@ -671,12 +849,15 @@ final class BenchmarkRegressionTests: XCTestCase {
         XCTAssertEqual(policy.currentLimit, 8)
 
         policy.recordCohort(Array(repeating: true, count: 4) + Array(repeating: false, count: 4))
-        XCTAssertEqual(policy.currentLimit, 4)
+        XCTAssertEqual(policy.currentLimit, 8)
 
         policy.recordCohort(Array(repeating: false, count: 8))
-        XCTAssertEqual(policy.currentLimit, 4)
+        XCTAssertEqual(policy.currentLimit, 8)
 
         policy.recordCohort(Array(repeating: true, count: 4))
+        XCTAssertEqual(policy.currentLimit, 12)
+
+        policy.recordCohort(Array(repeating: false, count: 12))
         XCTAssertEqual(policy.currentLimit, 8)
     }
 
@@ -772,10 +953,11 @@ final class BenchmarkRegressionTests: XCTestCase {
         wait(for: [replacementTasksStarted, completed], timeout: 2)
     }
 
-    func testSelectorRetryPolicyRetriesOnlyFailuresOnceAndUsesRetryResult() throws {
-        let names = ["First", "Second", "Third"]
+    func testSelectorReusesOnlySuccessfulEquivalentDirectLeafMeasurements() throws {
+        let url = "https://benchmark.example.test"
         let response = snapshot([
-            ["name": "Selector", "type": "Selector", "all": names, "now": names[0], "history": []],
+            ["name": "Selector", "type": "Selector", "all": ["Automatic", "First", "Second", "Third"], "now": "Automatic", "history": []],
+            ["name": "Automatic", "type": "URLTest", "all": ["First", "Second"], "now": "First", "testUrl": url, "history": []],
             ["name": "First", "type": "Trojan", "history": []],
             ["name": "Second", "type": "Vless", "history": []],
             ["name": "Third", "type": "Hysteria2", "history": []]
@@ -783,34 +965,16 @@ final class BenchmarkRegressionTests: XCTestCase {
         let plan = try SelectorBenchmarkPlan.make(
             selector: XCTUnwrap(response.proxiesMap["Selector"]),
             snapshot: response,
-            benchmarkURL: "https://benchmark.example.test",
+            benchmarkURL: url,
             timeout: 5
         )
-        let firstPass = Dictionary(uniqueKeysWithValues: zip(
-            plan.targets.map(\.key),
-            [120, 0, 0]
-        ))
-        let policy = SelectorBenchmarkRetryPolicy()
-        let retryTargets = policy.retryTargets(from: plan.targets, firstPassDelays: firstPass)
-
-        XCTAssertEqual(policy.maxConcurrentRequests, 2)
-        XCTAssertEqual(retryTargets.map(\.key.proxyName), ["Second", "Third"])
-        XCTAssertEqual(
-            policy.finalDelay(
-                for: retryTargets[0],
-                firstPassDelays: firstPass,
-                retryDelays: [retryTargets[0].key: 240]
-            ),
-            240
-        )
-        XCTAssertEqual(
-            policy.finalDelay(
-                for: retryTargets[1],
-                firstPassDelays: firstPass,
-                retryDelays: [:]
-            ),
-            0
-        )
+        let group = try XCTUnwrap(response.proxiesMap["Automatic"])
+        let delays = ["First": 120, "Second": 0, "Third": 300]
+        let reused = plan.reusableMeasurements(group: group, candidateDelays: delays, timeout: 5)
+        XCTAssertEqual(reused.count, 1)
+        XCTAssertEqual(reused.first?.key.proxyName, "First")
+        XCTAssertEqual(reused.first?.value, 120)
+        XCTAssertTrue(plan.reusableMeasurements(group: group, candidateDelays: delays, timeout: 10).isEmpty)
     }
 
     func testAdaptiveRunnerAppliesPolicyLimitChanges() {
@@ -838,28 +1002,59 @@ final class BenchmarkRegressionTests: XCTestCase {
         XCTAssertEqual(limitChanges.map(\.1), [12])
     }
 
-    func testSelectorRetryPolicyCapsTheFailureTail() throws {
-        let names = (1 ... 20).map { "Node \($0)" }
-        var proxies: [[String: Any]] = [
-            ["name": "Selector", "type": "Selector", "all": names, "now": names[0], "history": []]
-        ]
-        proxies.append(contentsOf: names.map {
-            ["name": $0, "type": "Vless", "history": []]
-        })
-        let response = snapshot(proxies)
-        let plan = try SelectorBenchmarkPlan.make(
-            selector: XCTUnwrap(response.proxiesMap["Selector"]),
-            snapshot: response,
-            benchmarkURL: "https://benchmark.example.test",
-            timeout: 5
-        )
-        let failures = Dictionary(uniqueKeysWithValues: plan.targets.map { ($0.key, 0) })
-        let policy = SelectorBenchmarkRetryPolicy()
+    func testSelectorDoesNotReuseDifferentURLStatusOrNestedGroupMeasurements() throws {
+        let url = "https://benchmark.example.test"
+        for (groupURL, status, members) in [
+            ("https://other.example.test", "", ["Leaf"]),
+            (url, "204", ["Leaf"]),
+            (url, "", ["Nested"])
+        ] {
+            let response = snapshot([
+                ["name": "Selector", "type": "Selector", "all": ["Automatic", "Leaf"], "now": "Automatic", "history": []],
+                ["name": "Automatic", "type": "URLTest", "all": members, "now": members[0], "testUrl": groupURL, "expectedStatus": status, "history": []],
+                ["name": "Nested", "type": "Selector", "all": ["Leaf"], "now": "Leaf", "history": []],
+                ["name": "Leaf", "type": "Vless", "history": []]
+            ])
+            let plan = try SelectorBenchmarkPlan.make(
+                selector: XCTUnwrap(response.proxiesMap["Selector"]), snapshot: response,
+                benchmarkURL: url, timeout: 5
+            )
+            XCTAssertTrue(try plan.reusableMeasurements(
+                group: XCTUnwrap(response.proxiesMap["Automatic"]),
+                candidateDelays: ["Leaf": 120, "Nested": 120], timeout: 5
+            ).isEmpty)
+        }
+    }
 
-        XCTAssertEqual(policy.retryTargets(
-            from: plan.targets,
-            firstPassDelays: failures
-        ).count, 4)
+    func testSelectorReuseRequiresMatchingProviderIdentity() throws {
+        let url = "https://benchmark.example.test"
+        let response = snapshot([
+            ["name": "Selector", "type": "Selector", "all": ["Automatic", "Leaf"], "now": "Automatic", "history": []],
+            ["name": "Automatic", "type": "URLTest", "all": ["Leaf"], "now": "Leaf", "testUrl": url, "history": []],
+            ["name": "Leaf", "type": "Vless", "history": []]
+        ])
+        let selector = try XCTUnwrap(response.proxiesMap["Selector"])
+        let group = try XCTUnwrap(response.proxiesMap["Automatic"])
+        let inlinePlan = SelectorBenchmarkPlan.make(selector: selector, snapshot: response, benchmarkURL: url, timeout: 5)
+        var firstProviderPlan: SelectorBenchmarkPlan?
+        for providerName in ["Subscription", "Other Subscription"] {
+            let data = try JSONSerialization.data(withJSONObject: ["providers": [providerName: [
+                "name": providerName, "type": "Proxy", "vehicleType": "HTTP",
+                "proxies": [["name": "Leaf", "type": "Vless", "history": []]]
+            ]]])
+            try response.updateProvider(ClashProviderResp.decoder.decode(ClashProviderResp.self, from: data))
+            XCTAssertTrue(inlinePlan.reusableMeasurements(group: group, candidateDelays: ["Leaf": 120], timeout: 5).isEmpty)
+            if let firstProviderPlan {
+                XCTAssertTrue(firstProviderPlan.reusableMeasurements(group: group, candidateDelays: ["Leaf": 120], timeout: 5).isEmpty)
+            } else {
+                firstProviderPlan = SelectorBenchmarkPlan.make(selector: selector, snapshot: response, benchmarkURL: url, timeout: 5)
+            }
+        }
+        let providerPlan = SelectorBenchmarkPlan.make(selector: selector, snapshot: response, benchmarkURL: url, timeout: 5)
+        let reused = providerPlan.reusableMeasurements(group: group, candidateDelays: ["Leaf": 120], timeout: 5)
+        XCTAssertEqual(reused.count, 1)
+        XCTAssertEqual(reused.first?.key.providerName, "Other Subscription")
+        XCTAssertEqual(reused.first?.key.endpoint, .provider)
     }
 
     func testProxyHistoryIsScopedToExactBenchmarkURL() throws {

--- a/ClashFXTests/IsolatedOperationTests.swift
+++ b/ClashFXTests/IsolatedOperationTests.swift
@@ -1,0 +1,412 @@
+import Foundation
+import XCTest
+
+/// No sockets, XPC, app singleton or production preferences are available here.
+final class IsolatedSystemProxyTests: XCTestCase {
+    private var suites = [(UserDefaults, String)]()
+
+    override func tearDown() {
+        for (defaults, name) in suites {
+            defaults.removePersistentDomain(forName: name)
+        }
+        suites.removeAll()
+        super.tearDown()
+    }
+
+    private let original: [String: Any] = [
+        SystemProxyOperationPolicy.capturedServiceIDsKey: ["wifi"],
+        "wifi": ["ProxyAutoConfigEnable": 1, "ProxyAutoConfigURLString": "https://example.test/original.pac", "HTTPEnable": 0]
+    ]
+
+    private final class Helper {
+        var current: [String: Any] = [:]
+        var events = [String]()
+        var readbackOverride: [String: Any]?
+        var restoreError: String?
+        var holdCapture = false
+        var holdEnable = false
+        var holdRestore = false
+        var captureReply: ((Any?) -> Void)?
+        var enableReply: ((String?) -> Void)?
+        var restoreReply: ((String?) -> Void)?
+        var onEvent: ((String) -> Void)?
+        var duplicateReplies = false
+
+        func record(_ event: String) {
+            XCTAssertTrue(Thread.isMainThread)
+            events.append(event)
+            onEvent?(event)
+        }
+
+        var client: SystemProxyHelperClient {
+            SystemProxyHelperClient(
+                getCurrentProxySetting: { reply in
+                    DispatchQueue.main.async {
+                        self.record("capture")
+                        if self.holdCapture { self.captureReply = reply; return }
+                        reply(self.readbackOverride ?? self.current)
+                        if self.duplicateReplies { reply(self.current) }
+                    }
+                },
+                enable: { port, socks, _, _, reply in
+                    DispatchQueue.main.async {
+                        self.record("enable")
+                        self.current = [SystemProxyOperationPolicy.capturedServiceIDsKey: ["wifi"],
+                                        "wifi": ["HTTPEnable": 1, "HTTPPort": port, "SOCKSPort": socks]]
+                        if self.holdEnable { self.enableReply = reply; return }
+                        reply(nil)
+                        if self.duplicateReplies { reply(nil) }
+                    }
+                },
+                disable: { _, reply in
+                    DispatchQueue.main.async { self.record("disable"); reply(nil) }
+                },
+                restore: { _, _, info, _, reply in
+                    DispatchQueue.main.async {
+                        self.record("restore")
+                        if self.restoreError == nil { self.current = info }
+                        if self.holdRestore { self.restoreReply = reply; return }
+                        reply(self.restoreError)
+                        if self.duplicateReplies { reply(self.restoreError) }
+                    }
+                }
+            )
+        }
+    }
+
+    private func environment(_ helper: Helper, timeout: TimeInterval = 1,
+                             unavailable: Bool = false) throws -> (SystemProxyManager, UserDefaults) {
+        let suite = "com.clashfx.isolated-tests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        suites.append((defaults, suite))
+        helper.current = original
+        let dependencies = SystemProxyDependencies(
+            defaults: defaults, helper: { failure in
+                if unavailable { failure(); return nil }
+                return helper.client
+            }, currentPorts: { (7890, 7891) },
+            shouldSuspend: { false }, disableRestoreProxy: { false }, filterInterface: { true },
+            proxyIgnoreList: { [] }, liveSystemPointsToClashFX: { false }, stageTimeout: timeout
+        )
+        return (SystemProxyManager(dependencies: dependencies), defaults)
+    }
+
+    private func enable(_ manager: SystemProxyManager) {
+        let completed = expectation(description: "enable completed")
+        completed.assertForOverFulfill = true
+        manager.enableProxy { success in
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertTrue(success)
+            completed.fulfill()
+        }
+        wait(for: [completed], timeout: 2)
+    }
+
+    private func restore(_ manager: SystemProxyManager, succeeds: Bool) {
+        let completed = expectation(description: "restore completed")
+        completed.assertForOverFulfill = true
+        manager.prepareForTermination()
+        manager.restoreForTermination { success in
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(success, succeeds)
+            completed.fulfill()
+        }
+        wait(for: [completed], timeout: 2)
+    }
+
+    func testRealManagerRestoresPACAndVerifiesBeforeClearingSnapshot() throws {
+        let helper = Helper()
+        helper.duplicateReplies = true
+        let (manager, defaults) = try environment(helper)
+        enable(manager)
+        XCTAssertTrue(defaults.bool(forKey: SystemProxyOperationPolicy.savedSnapshotValidityKey))
+        restore(manager, succeeds: true)
+        XCTAssertEqual(helper.events, ["capture", "enable", "restore", "capture"])
+        XCTAssertTrue(NSDictionary(dictionary: original).isEqual(to: helper.current))
+        XCTAssertNil(defaults.object(forKey: SystemProxyOperationPolicy.savedSnapshotKey))
+        XCTAssertFalse(defaults.bool(forKey: SystemProxyOperationPolicy.savedSnapshotValidityKey))
+    }
+
+    func testQuitWaitsForInFlightEnableAndRejectsNewEnable() throws {
+        let helper = Helper()
+        helper.holdEnable = true
+        let (manager, _) = try environment(helper)
+        let started = expectation(description: "in-flight enable")
+        helper.onEvent = { if $0 == "enable" { started.fulfill() } }
+        let first = expectation(description: "first enable completed")
+        manager.enableProxy { XCTAssertTrue($0); first.fulfill() }
+        wait(for: [started], timeout: 2)
+        manager.prepareForTermination()
+        let blocked = expectation(description: "new enable blocked")
+        manager.enableProxy { XCTAssertFalse($0); blocked.fulfill() }
+        let restored = expectation(description: "restore completed")
+        manager.restoreForTermination { XCTAssertTrue($0); restored.fulfill() }
+        XCTAssertEqual(helper.events, ["capture", "enable"])
+        helper.enableReply?(nil)
+        wait(for: [first, blocked, restored], timeout: 2)
+        XCTAssertEqual(helper.events, ["capture", "enable", "restore", "capture"])
+    }
+
+    func testQuitDuringCaptureDoesNotEnableAfterCaptureCompletes() throws {
+        let helper = Helper()
+        helper.holdCapture = true
+        let (manager, _) = try environment(helper)
+        let started = expectation(description: "capture started")
+        helper.onEvent = { if $0 == "capture" { started.fulfill() } }
+        let enabled = expectation(description: "enable aborted")
+        manager.enableProxy { XCTAssertFalse($0); enabled.fulfill() }
+        wait(for: [started], timeout: 2)
+        helper.onEvent = nil
+        manager.prepareForTermination()
+        let restored = expectation(description: "restored without enabling")
+        manager.restoreForTermination { XCTAssertTrue($0); restored.fulfill() }
+        helper.holdCapture = false
+        helper.captureReply?(original)
+        wait(for: [enabled, restored], timeout: 2)
+        XCTAssertEqual(helper.events, ["capture", "restore", "capture"])
+    }
+
+    func testReadbackMismatchKeepsSnapshotAndAllowsRetry() throws {
+        let helper = Helper()
+        let (manager, defaults) = try environment(helper)
+        enable(manager)
+        helper.readbackOverride = [SystemProxyOperationPolicy.capturedServiceIDsKey: ["wifi"], "wifi": ["HTTPEnable": 1]]
+        restore(manager, succeeds: false)
+        XCTAssertTrue(defaults.bool(forKey: SystemProxyOperationPolicy.savedSnapshotValidityKey))
+        XCTAssertTrue(try NSDictionary(dictionary: original).isEqual(to: XCTUnwrap(defaults.dictionary(forKey: SystemProxyOperationPolicy.savedSnapshotKey))))
+        helper.readbackOverride = nil
+        manager.resumeAfterCancelledTermination()
+        restore(manager, succeeds: true)
+        XCTAssertEqual(helper.events, ["capture", "enable", "restore", "capture", "restore", "capture"])
+    }
+
+    func testRestoreErrorRetainsOriginalSnapshotForRetry() throws {
+        let helper = Helper()
+        let (manager, defaults) = try environment(helper)
+        enable(manager)
+        helper.restoreError = "simulated permission failure"
+        restore(manager, succeeds: false)
+        XCTAssertTrue(defaults.bool(forKey: SystemProxyOperationPolicy.savedSnapshotValidityKey))
+        XCTAssertEqual(helper.events, ["capture", "enable", "restore"])
+        helper.restoreError = nil
+        manager.resumeAfterCancelledTermination()
+        restore(manager, succeeds: true)
+    }
+
+    func testRestoreTimeoutAndLateCallbackCannotClearSnapshot() throws {
+        let helper = Helper()
+        let (manager, defaults) = try environment(helper, timeout: 0.25)
+        enable(manager)
+        helper.holdRestore = true
+        restore(manager, succeeds: false)
+        helper.restoreReply?(nil)
+        XCTAssertTrue(defaults.bool(forKey: SystemProxyOperationPolicy.savedSnapshotValidityKey))
+        helper.holdRestore = false
+        manager.resumeAfterCancelledTermination()
+        restore(manager, succeeds: true)
+        XCTAssertEqual(helper.events, ["capture", "enable", "restore", "restore", "capture"])
+    }
+
+    func testCaptureTimeoutAndLateCallbackNeverEnableOrSaveSnapshot() throws {
+        let helper = Helper()
+        helper.holdCapture = true
+        let (manager, defaults) = try environment(helper, timeout: 0.25)
+        let failed = expectation(description: "capture timed out")
+        manager.enableProxy { XCTAssertFalse($0); failed.fulfill() }
+        wait(for: [failed], timeout: 2)
+        helper.captureReply?(original)
+        // A following operation is a barrier through the production operation queue.
+        manager.prepareForTermination()
+        let blocked = expectation(description: "late enable blocked")
+        manager.enableProxy { XCTAssertFalse($0); blocked.fulfill() }
+        wait(for: [blocked], timeout: 2)
+        XCTAssertEqual(helper.events, ["capture"])
+        XCTAssertNil(defaults.object(forKey: SystemProxyOperationPolicy.savedSnapshotKey))
+    }
+
+    func testUnavailableHelperSettlesOnceWithoutSavingOrEnabling() throws {
+        let helper = Helper()
+        let (manager, defaults) = try environment(helper, unavailable: true)
+        let failed = expectation(description: "unavailable helper")
+        manager.enableProxy { XCTAssertFalse($0); failed.fulfill() }
+        wait(for: [failed], timeout: 2)
+        XCTAssertTrue(helper.events.isEmpty)
+        XCTAssertNil(defaults.object(forKey: SystemProxyOperationPolicy.savedSnapshotKey))
+    }
+
+    func testCaptureErrorDoesNotOverwriteOriginalOrEnable() throws {
+        let helper = Helper()
+        let (manager, defaults) = try environment(helper)
+        helper.readbackOverride = [SystemProxyOperationPolicy.captureErrorKey: "simulated read failure"]
+        let failed = expectation(description: "capture rejected")
+        manager.enableProxy { XCTAssertFalse($0); failed.fulfill() }
+        wait(for: [failed], timeout: 2)
+        XCTAssertEqual(helper.events, ["capture"])
+        XCTAssertNil(defaults.object(forKey: SystemProxyOperationPolicy.savedSnapshotKey))
+    }
+
+    func testCancelledQuitCanEnableAgainWithoutReplacingOriginalSnapshot() throws {
+        let helper = Helper()
+        let (manager, _) = try environment(helper)
+        enable(manager)
+        manager.prepareForTermination()
+        let blocked = expectation(description: "enable blocked during quit")
+        manager.enableProxy { XCTAssertFalse($0); blocked.fulfill() }
+        wait(for: [blocked], timeout: 2)
+        manager.resumeAfterCancelledTermination()
+        enable(manager)
+        restore(manager, succeeds: true)
+        XCTAssertEqual(helper.events, ["capture", "enable", "enable", "restore", "capture"])
+        XCTAssertTrue(NSDictionary(dictionary: original).isEqual(to: helper.current))
+    }
+}
+
+final class IsolatedSelectorExecutionTests: XCTestCase {
+    /// Deadlines are virtual milliseconds. No real network or wall-clock waits.
+    private final class Transport {
+        struct Pending { let deadline: Int; let delay: Int; let reply: (Int) -> Void }
+        let queue = DispatchQueue(label: "com.clashfx.tests.virtual-transport")
+        var now = 0
+        var peak = 0
+        var pending = [Pending]()
+        var requested = [String]()
+        var launchedAt = [String: Int]()
+        var results = [String: Int]()
+        var cancelled = false
+        var duplicateReplies = false
+        var timing: (SelectorBenchmarkPlan.Target) -> (Int, Int) = { _ in (500, 120) }
+
+        func request(_ target: SelectorBenchmarkPlan.Target, reply: @escaping (Int) -> Void) {
+            requested.append(target.key.proxyName)
+            launchedAt[target.key.proxyName] = now
+            let (duration, delay) = timing(target)
+            pending.append(Pending(deadline: now + duration, delay: delay, reply: reply))
+            peak = max(peak, pending.count)
+        }
+
+        func advanceOneDeadline() -> Bool {
+            queue.sync {
+                guard let deadline = pending.map(\.deadline).min() else { return false }
+                now = deadline
+                let ready = pending.filter { $0.deadline == deadline }
+                pending.removeAll { $0.deadline == deadline }
+                for event in ready {
+                    event.reply(event.delay)
+                    if duplicateReplies { event.reply(event.delay) }
+                }
+                return true
+            }
+        }
+
+        func drain() {
+            // Each sync first drains the executor callbacks queued by the prior step.
+            for _ in 0 ..< 1000 {
+                if !advanceOneDeadline() { return }
+            }
+            XCTFail("executor did not settle")
+        }
+    }
+
+    private func plan(count: Int) -> SelectorBenchmarkPlan {
+        let names = (0 ..< count).map { "Node \($0)" }
+        var proxies: [String: Any] = ["Selector": ["name": "Selector", "type": "Selector", "all": names, "now": names.first ?? "", "history": []]]
+        for name in names {
+            proxies[name] = ["name": name, "type": "Vless", "history": []]
+        }
+        let snapshot = ClashProxyResp(try! JSONSerialization.data(withJSONObject: ["proxies": proxies]))
+        return SelectorBenchmarkPlan.make(selector: snapshot.proxiesMap["Selector"]!, snapshot: snapshot,
+                                          benchmarkURL: "https://example.test/virtual", timeout: 5000)
+    }
+
+    private func start(_ plan: SelectorBenchmarkPlan, transport: Transport,
+                       reused: [SelectorBenchmarkMeasurementKey: Int] = [:]) -> XCTestExpectation {
+        let complete = expectation(description: "executor completes once")
+        complete.assertForOverFulfill = true
+        // Start on the injected serial queue; all fake transport state stays on it.
+        transport.queue.async {
+            SelectorBenchmarkExecutor.run(
+                plan: plan, reusing: reused, isCancelled: { transport.cancelled },
+                schedulingQueue: transport.queue,
+                request: { transport.request($0, reply: $1) },
+                result: { transport.results[$0.key.proxyName] = $1 },
+                completion: { XCTAssertTrue(Thread.isMainThread); complete.fulfill() }
+            )
+        }
+        transport.queue.sync {} // let run enqueue the runner's start
+        transport.queue.sync {} // let the runner fill its initial slots
+        return complete
+    }
+
+    func testHealthyBatchUsesBoundedRollingConcurrencyAndIgnoresDuplicateReplies() {
+        let transport = Transport()
+        transport.duplicateReplies = true
+        let complete = start(plan(count: 24), transport: transport)
+        transport.drain()
+        wait(for: [complete], timeout: 2)
+        XCTAssertEqual(transport.now, 1500)
+        XCTAssertEqual(transport.peak, 12)
+        XCTAssertEqual(transport.requested.count, 24)
+        XCTAssertEqual(Set(transport.requested).count, 24)
+        XCTAssertEqual(transport.results.count, 24)
+    }
+
+    func testAllTimeoutsHaveNoRetryTailOrConcurrencyCollapse() {
+        let transport = Transport()
+        transport.timing = { ($0.key.timeout, 0) }
+        let complete = start(plan(count: 24), transport: transport)
+        transport.drain()
+        wait(for: [complete], timeout: 2)
+        XCTAssertEqual(transport.now, 15000) // exactly three windows, not retry windows
+        XCTAssertEqual(transport.peak, 8)
+        XCTAssertEqual(transport.requested.count, 24)
+        XCTAssertEqual(transport.results.count, 24)
+        XCTAssertTrue(transport.results.values.allSatisfy { $0 == 0 })
+    }
+
+    func testOneSlowNodeDoesNotBlockOtherRequestsFromStarting() {
+        let transport = Transport()
+        transport.timing = { $0.key.proxyName == "Node 0" ? (5000, 0) : (500, 120) }
+        let complete = start(plan(count: 24), transport: transport)
+        transport.drain()
+        wait(for: [complete], timeout: 2)
+        XCTAssertEqual(transport.now, 5000)
+        XCTAssertLessThan(transport.launchedAt.values.max() ?? 5000, 5000)
+        XCTAssertEqual(transport.requested.count, 24)
+        XCTAssertEqual(transport.results.count, 24)
+    }
+
+    func testReusedMeasurementsIssueNoRequests() {
+        let transport = Transport()
+        let plan = plan(count: 24)
+        let measurements = Dictionary(uniqueKeysWithValues: plan.targets.map { ($0.key, 123) })
+        let complete = start(plan, transport: transport, reused: measurements)
+        transport.drain()
+        wait(for: [complete], timeout: 2)
+        XCTAssertEqual(transport.now, 0)
+        XCTAssertTrue(transport.requested.isEmpty)
+        XCTAssertEqual(transport.results.count, 24)
+    }
+
+    func testCancellationSuppressesLateResultsAndQueuedRequests() {
+        let transport = Transport()
+        let complete = start(plan(count: 24), transport: transport)
+        transport.queue.sync { transport.cancelled = true }
+        transport.drain()
+        wait(for: [complete], timeout: 2)
+        XCTAssertEqual(transport.requested.count, 8)
+        XCTAssertTrue(transport.results.isEmpty)
+    }
+
+    func testInvalidReuseStillRequestsAndEmptyPlanCompletes() {
+        for count in [0, 2] {
+            let transport = Transport()
+            let plan = plan(count: count)
+            let measurements = Dictionary(uniqueKeysWithValues: plan.targets.map { ($0.key, 0) })
+            let complete = start(plan, transport: transport, reused: measurements)
+            transport.drain()
+            wait(for: [complete], timeout: 2)
+            XCTAssertEqual(transport.requested.count, count)
+            XCTAssertEqual(transport.results.count, count)
+        }
+    }
+}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,35 @@
 ### Bug Fixes
 
+- **Large Selector Benchmarks Finish Without a Retry Tail** — Selector rows now use a bounded rolling pool of 8–12 requests, settle failures immediately instead of retrying them after the full pass, and reuse successful direct-leaf measurements from the selected automatic-group retest only when URL, timeout, expected-status semantics, and provider identity match. Mihomo's fresh `now` remains authoritative. (#147)
+- **Quitting Reliably Restores the Original System Proxy** — Proxy transitions now serialize the complete asynchronous Helper operations, block new enable/recovery work while quitting, and avoid a second disable after restoration. ClashFX reads the settings back before exiting; a failed, timed-out, or mismatched restore keeps the original snapshot and cancels termination so the user can retry. (#147)
+- **Old Delay Results No Longer Make Usable Menus Look Disabled** — The 30-minute stale state no longer fades whole node rows or automatic-group menus. Nodes remain normally legible and selectable while current, failed, and unavailable delay badges continue to describe benchmark state. Automatic-group child rows also retain the newest applicable global measurement. (#147, #219)
+- **Legacy WebKit Theme Colors Are Converted Instead of Turning Black** — The dashboard compatibility layer now detects real `color-mix()` support with CSS variables and converts RGB, Lab, and OKLab fallback colors on older Safari/WebKit engines, preventing dark themes from losing their intended backgrounds and contrast. (#221)
+
+### Contributors
+
+- @a51095 — Reported slow Selector completion, proxy restoration on quit, and stale rows appearing disabled. (#147)
+- @0nelab — Retested automatic-group delay visibility and legacy WebKit theme rendering. (#219, #221)
+
+---
+
+### 修复
+
+- **大型 Selector 测速不再附加失败重试尾部** — Selector 现在使用 8～12 个请求的有界滚动并发；失败结果会立即结算，不再等整轮结束后重试。选中自动策略重测得到的成功叶子结果，只有在 URL、超时、expected-status 语义及 Provider 身份完全一致时才会复用；选中路径仍只以 Mihomo 最新 `now` 为准。 (#147)
+- **退出时会可靠恢复原系统代理** — 系统代理转换会等待前一项异步 Helper 操作真正完成；退出期间会阻止新的启用与网络恢复任务，恢复完成后也不会再次关闭代理。退出前会读回核对设置；若恢复失败、超时或不一致，会保留原始快照并取消退出，方便用户重试。 (#147)
+- **旧测速结果不再让可用菜单看起来像被禁用** — 30 分钟后的过期状态不再降低整行节点或自动策略菜单的透明度。节点文字保持正常可读、仍可选择，同时继续通过延迟徽标区分当前、失败与不可用状态；自动策略子节点也会保留最新适用的全局测速结果。 (#147, #219)
+- **旧版 WebKit 的主题颜色会正确转换而不是变黑** — 控制台兼容层现在会结合 CSS 变量检测真实的 `color-mix()` 支持，并在旧版 Safari/WebKit 上转换 RGB、Lab 与 OKLab 后备颜色，避免暗色主题丢失背景色和对比度。 (#221)
+
+### 贡献者
+
+- @a51095 — 反馈 Selector 完成过慢、退出未恢复代理，以及过期节点看起来被禁用的问题。 (#147)
+- @0nelab — 协助复测自动策略子节点延迟显示和旧版 WebKit 主题渲染。 (#219, #221)
+
+<!-- Previous release notes -->
+
+---
+
+### Bug Fixes
+
 - **Selected Automatic Results Arrive Before the Selector Retry Tail** — A selected automatic group is now retested first with its own URL and expected status, then published from Mihomo's fresh `now` before leaf rows begin. Selector concurrency grows only after complete launch cohorts settle, is capped at twelve, and retries at most four failed targets, preventing a long failure tail from hiding the result users asked for. (#147)
 - **Automatic-Group Leaf Delays Are Visible and Generation-Safe** — Automatic-group submenus now render URL-scoped delay badges for every direct candidate. Results carry group membership, benchmark URL, expected status, session identity, and expiry metadata, so provider changes and late callbacks cannot leave misleading group or leaf values behind. Mihomo's fresh `now` remains the only authority for the selected path. (#219)
 - **Dashboard Themes Persist and Legacy WebKit Renders Safely** — Opening or upgrading the dashboard now clears only volatile caches and preserves local storage, cookies, and IndexedDB. A capability-gated compatibility layer replaces unsupported `color-mix()` transparency on older WebKit and supplies cached theme preview colors without forcing layout for every theme. (#221, #223)

--- a/docs/BENCHMARK-COMPARISON.md
+++ b/docs/BENCHMARK-COMPARISON.md
@@ -1,0 +1,59 @@
+# 手动延迟测速对比与 #147 修复
+
+调研日期：2026-09-08。以下是源码行为对比，不是同订阅、同网络的实测排名。
+
+## 竞品源码
+
+| 项目 | 策略组列表测速 | 并发与失败处理 | 结果展示 |
+| --- | --- | --- | --- |
+| Clash Party | 对列表候选逐个调用节点 delay / Provider healthcheck | 默认 50，完成一个补一个；默认超时 5000 ms；没有整轮结束后的自动重试 | 200 ms 合并刷新 |
+| Clash Verge Rev | 对列表候选逐个调用测速 | 参数默认 36，但实际限制为 10；滚动补位，最多 200 ms 启动抖动；无整轮失败重试 | 节点结果逐步更新，测量展示至少 500 ms |
+| ClashFX（本次修改前） | Selector 优先显式重测选中的自动组，再测可比较的叶子节点 | 初始 8、最高 12，失败密集时降到 4；结束后最多重试 4 个失败节点，并发 2 | 结果合并刷新，重试节点要等第二次结束 |
+
+已核对的固定版本源码：
+
+- [Clash Party：列表请求池](https://github.com/mihomo-party-org/clash-party/blob/2a19b0226627b5796503b1556e583fa909485fee/src/renderer/src/pages/proxies.tsx#L345)、[API URL 与超时](https://github.com/mihomo-party-org/clash-party/blob/2a19b0226627b5796503b1556e583fa909485fee/src/main/core/mihomoApi.ts#L390)。
+- [Clash Verge Rev：实际并发和节点测量](https://github.com/clash-verge-rev/clash-verge-rev/blob/f754ee53a0b25ed3b115f978838947455cacecef/src/services/delay.ts#L270)。
+
+这些是调研时的分支快照，不应等同于反馈用户安装的版本。客户端请求数量也不等于内核内部实际探测并发。
+
+## 本次采用的优化
+
+1. 删除 Selector 整轮结束后的失败重试。成功、失败均立即结算；用户需要时可重新点击测速，避免少量离线节点追加两批超时等待。
+2. 维持滚动并发 8–12，不再仅因失败多降到 4。节点不可用不能单独证明本机拥塞；暂不照搬 Party 的 50 并发，避免在旧机器和较差网络上放大争用。
+3. 复用同一次操作中自动组已经测得的成功叶子结果。必须同时匹配 URL、超时、默认状态码语义、直接成员、节点名以及 Provider/inline 身份。不同 URL、自定义 expected-status、嵌套组路径、失败及历史缓存均不复用。
+4. 保持 Mihomo 新鲜 `now` 的权威性。比较测速不会用最小延迟擅自改写自动组选路；需要重测自动组时仍使用该组的 URL 和 expected-status。
+5. 保留取消与会话身份检查、别名去重和合并刷新，不按每个结果重建整个菜单。
+
+全局叶子测速原先就是固定 8 并发且不自动重试；本次 Selector 优化不代表全局入口也存在相同重试问题。
+
+## 菜单与退出问题
+
+- 整体淡化来自 `5016df809` 引入的过期展示（30 分钟后 alpha 0.65），以及 `b457b44e0` 中自动组的同类处理；不是“测速不可用”触发的网络禁用。本次移除整行透明度和文字变灰处理，保留结果状态及其时间戳，不改变节点可选性。
+- 系统代理操作改为等待整个异步操作完成后再开始下一项；退出期间停止新启用和网络恢复请求。正常退出不再在恢复后二次关闭代理，恢复完成后读回检查原设置，失败保留快照并取消退出，供重试。
+
+## 验证边界
+
+自动测试覆盖复用的匹配/拒绝条件、并发补位和上限、异步代理操作串行与重复回调、PAC/开关位和网络服务增删的恢复核对。使用非 Beta 的 Xcode 26.6。
+
+本次本机 XCTest 结果：107 项通过，0 失败（其中新增 16 项隔离执行测试；arm64，macOS 26.6.1）。Release 应用分别完成 arm64 / x86_64 构建，并检查 Dashboard 兼容资源已进入包内。构建成功不等同于已在旧版 macOS 或 Intel 真机上运行验证。
+
+仍需用反馈用户同一订阅、相同测速 URL 和超时做网络实测，才能判断是否达到其描述的十多秒。系统代理与增强模式同时开启后退出，须在带签名 Helper 的真实运行包上检查系统设置；纯单元测试不替代该端到端验证。
+
+## 使用中的隔离测试
+
+`ClashFXTests/IsolatedOperationTests.swift` 直接测试生产 `SelectorBenchmarkExecutor` 和 `SystemProxyManager`。主程序仅把真实请求和 XPC 作为依赖接入：`SystemProxyManager+Live.swift` 只加入 App target，不进入无宿主的测试 target。测试没有主程序单例、真实 Helper、DNS 操作或真实测速请求；每个代理测试使用独立 UUID 命名的 UserDefaults suite，结束仅清理自己创建的 suite。
+
+- 测速：虚拟时钟驱动请求完成，覆盖健康批次、全超时、单个慢节点、结果复用、无效复用、取消、空计划和重复回调。人为设定的 24 节点、每请求超时 5000 ms 场景应恰好消耗三轮虚拟超时窗口，无追加重试；这不是实际网络速度的测量。
+- 代理：模拟捕获、启用、恢复和读回，覆盖 PAC 原样恢复、等待在途启用、退出期间阻止启用、恢复错误/超时/不匹配后的快照保留与重试、取消退出后再启用、Helper 不可用、捕获错误/超时及迟到回调。生产八秒阶段超时在测试中缩短到 250 ms。
+
+可在不退出当前 ClashFX 的情况下运行（正式版 Xcode 26.6，限制编译并行度）：
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode-26.6.0.app/Contents/Developer xcodebuild test \
+  -workspace ClashFX.xcworkspace -scheme ClashFX \
+  -destination 'platform=macOS,arch=arm64' -jobs 2 \
+  -derivedDataPath /tmp/clashfx-isolated-safety-tests CODE_SIGNING_ALLOWED=NO
+```
+
+此命令不启动 App、不安装 Helper、不替换当前运行包。仍不能用模拟测试证明签名权限、系统网络服务提交或真实 TUN/DNS 恢复成功。


### PR DESCRIPTION
## Summary

- finish Selector benchmarks without a failed-node retry tail, reuse only equivalent current-action automatic-group measurements, and keep concurrency bounded at 8–12
- restore original system proxy settings through fully serialized Helper operations with readback verification and retry-safe snapshot retention
- stop fading entire stale proxy rows, preserve applicable automatic-group child delays, and improve legacy Safari/WebKit theme color conversion
- add isolated production-executor and proxy-manager tests plus release notes and benchmark comparison documentation

## Verification

- Xcode 26.6 (non-Beta): 107 XCTest cases passed, 0 failed
- Release build passed for arm64/universal and x86_64
- Dashboard compatibility bundle verified in both Release products
- `git diff --check` passed
- tests are unhosted and use virtual benchmark transport, mock Helper, and UUID-scoped UserDefaults; they do not launch ClashFX or alter live proxy/DNS state

## Issues

Refs #147, #219, #221